### PR TITLE
Remove "Payment" files from package manifest

### DIFF
--- a/browser/installer/package-manifest.in
+++ b/browser/installer/package-manifest.in
@@ -243,6 +243,9 @@
 #ifdef MOZ_GAMEPAD
 @RESPATH@/components/dom_gamepad.xpt
 #endif
+#ifdef MOZ_PAY
+@RESPATH@/components/dom_payment.xpt
+#endif
 @RESPATH@/components/dom_presentation.xpt
 @RESPATH@/components/downloads.xpt
 @RESPATH@/components/editor.xpt
@@ -587,6 +590,12 @@
 @RESPATH@/components/ActivityRequestHandler.js
 @RESPATH@/components/ActivityWrapper.js
 @RESPATH@/components/ActivityMessageConfigurator.js
+#endif
+
+#ifdef MOZ_PAY
+@RESPATH@/components/Payment.js
+@RESPATH@/components/PaymentFlowInfo.js
+@RESPATH@/components/Payment.manifest
 #endif
 
 #ifdef MOZ_WEBRTC

--- a/browser/installer/package-manifest.in
+++ b/browser/installer/package-manifest.in
@@ -243,7 +243,6 @@
 #ifdef MOZ_GAMEPAD
 @RESPATH@/components/dom_gamepad.xpt
 #endif
-@RESPATH@/components/dom_payment.xpt
 @RESPATH@/components/dom_presentation.xpt
 @RESPATH@/components/downloads.xpt
 @RESPATH@/components/editor.xpt
@@ -589,10 +588,6 @@
 @RESPATH@/components/ActivityWrapper.js
 @RESPATH@/components/ActivityMessageConfigurator.js
 #endif
-
-@RESPATH@/components/Payment.js
-@RESPATH@/components/PaymentFlowInfo.js
-@RESPATH@/components/Payment.manifest
 
 #ifdef MOZ_WEBRTC
 @RESPATH@/components/PeerConnection.js


### PR DESCRIPTION
Linux builds fail with the following:

```
Error: /home/trava90/PaleMoon/Tycho/pmbuild/browser/installer/package-manifest:132: Missing file(s): bin/components/dom_payment.xpt
Error: /home/trava90/PaleMoon/Tycho/pmbuild/browser/installer/package-manifest:406: Missing file(s): bin/components/Payment.js
Error: /home/trava90/PaleMoon/Tycho/pmbuild/browser/installer/package-manifest:407: Missing file(s): bin/components/PaymentFlowInfo.js
Error: /home/trava90/PaleMoon/Tycho/pmbuild/browser/installer/package-manifest:408: Missing file(s): bin/components/Payment.manifest
Traceback (most recent call last):
  File "/home/trava90/PaleMoon/Tycho/Tycho/toolkit/mozapps/installer/packager.py", line 403, in <module>
    main()
  File "/home/trava90/PaleMoon/Tycho/Tycho/toolkit/mozapps/installer/packager.py", line 352, in main
    copier.add(mozpath.join(respath, 'removed-files'), removals)
  File "/usr/local/lib/python2.7/contextlib.py", line 24, in __exit__
    self.gen.next()
  File "/home/trava90/PaleMoon/Tycho/Tycho/python/mozbuild/mozpack/errors.py", line 129, in accumulate
    raise AccumulatedErrors()
mozpack.errors.AccumulatedErrors
```
This PR removes the "Payment" files listed above from the package manifest, allowing the build to complete successfully.