### PR TITLE
Port a few fixes over from the current Pale Moon codebase

### DIFF
--- a/toolkit/content/widgets/findbar.xml
+++ b/toolkit/content/widgets/findbar.xml
@@ -636,6 +636,8 @@
           this._findField.blur();
 
           this._cancelTimers();
+          this.toggleHighlight(false);
+          this.getElement("highlight").checked = false;
 
           this._findFailedString = null;
         ]]></body>

--- a/toolkit/mozapps/extensions/internal/XPIProvider.jsm
+++ b/toolkit/mozapps/extensions/internal/XPIProvider.jsm
@@ -6744,8 +6744,12 @@ function AddonWrapper(aAddon) {
         }
       }
 
-      if (result == null)
-        [result, ] = chooseValue(aAddon.selectedLocale, aProp);
+      if (result == null) {
+        if (typeof aAddon.selectedLocale[aProp] == "string" && aAddon.selectedLocale[aProp].length)
+          [result, ] = chooseValue(aAddon.selectedLocale, aProp);
+        else
+          [result, ] = chooseValue(aAddon.defaultLocale, aProp);
+      }
 
       if (aProp == "creator")
         return result ? new AddonManagerPrivate.AddonAuthor(result) : null;
@@ -6774,8 +6778,12 @@ function AddonWrapper(aAddon) {
         }
       }
 
-      if (results == null)
-        [results, usedRepository] = chooseValue(aAddon.selectedLocale, aProp);
+      if (results == null) {
+        if (aAddon.selectedLocale[aProp] instanceof Array && aAddon.selectedLocale[aProp].length)
+          [results, usedRepository] = chooseValue(aAddon.selectedLocale, aProp);
+        else
+          [results, usedRepository] = chooseValue(aAddon.defaultLocale, aProp);
+      }
 
       if (results && !usedRepository) {
         results = results.map(function mapResult(aResult) {

--- a/toolkit/xre/nsEmbedFunctions.cpp
+++ b/toolkit/xre/nsEmbedFunctions.cpp
@@ -395,18 +395,18 @@ XRE_InitChildProcess(int aArgc,
   }
 #endif
 
-  SetupErrorHandling(aArgv[0]);  
+  SetupErrorHandling(aArgv[0]);
 
 #if defined(MOZ_CRASHREPORTER)
   if (aArgc < 1)
     return NS_ERROR_FAILURE;
   const char* const crashReporterArg = aArgv[--aArgc];
-  
+
 #  if defined(XP_WIN) || defined(XP_MACOSX)
   // on windows and mac, |crashReporterArg| is the named pipe on which the
   // server is listening for requests, or "-" if crash reporting is
   // disabled.
-  if (0 != strcmp("-", crashReporterArg) && 
+  if (0 != strcmp("-", crashReporterArg) &&
       !XRE_SetRemoteExceptionHandler(crashReporterArg)) {
     // Bug 684322 will add better visibility into this condition
     NS_WARNING("Could not setup crash reporting\n");
@@ -414,21 +414,21 @@ XRE_InitChildProcess(int aArgc,
 #  elif defined(OS_LINUX)
   // on POSIX, |crashReporterArg| is "true" if crash reporting is
   // enabled, false otherwise
-  if (0 != strcmp("false", crashReporterArg) && 
+  if (0 != strcmp("false", crashReporterArg) &&
       !XRE_SetRemoteExceptionHandler(nullptr)) {
     // Bug 684322 will add better visibility into this condition
     NS_WARNING("Could not setup crash reporting\n");
   }
 #  else
 #    error "OOP crash reporting unsupported on this platform"
-#  endif   
+#  endif
 #endif // if defined(MOZ_CRASHREPORTER)
 
   gArgv = aArgv;
   gArgc = aArgc;
 
-#if defined(MOZ_WIDGET_GTK)
-  g_thread_init(nullptr);
+#if MOZ_WIDGET_GTK == 2
+  XRE_GlibInit();
 #endif
 
 #if defined(MOZ_WIDGET_QT)
@@ -551,7 +551,7 @@ XRE_InitChildProcess(int aArgc,
       case GoannaProcessType_IPDLUnitTest:
 #ifdef MOZ_IPDL_TESTS
         process = new IPDLUnitTestProcessChild(parentHandle);
-#else 
+#else
         NS_RUNTIMEABORT("rebuild with --enable-ipdl-tests");
 #endif
         break;
@@ -611,7 +611,7 @@ public:
                        void* aData)
   : mFunction(aFunction),
     mData(aData)
-  { 
+  {
     NS_ASSERTION(aFunction, "Don't give me a null pointer!");
   }
 
@@ -708,7 +708,7 @@ XRE_RunAppShell()
       // Cocoa nsAppShell impl, however, implements its own Run()
       // that's unaware of MessagePump.  That's all rather suboptimal,
       // but oddly enough not a problem... usually.
-      // 
+      //
       // The problem with this setup comes during startup.
       // XPCOM-in-subprocesses depends on IPC, e.g. to init the pref
       // service, so we have to init IPC first.  But, IPC also
@@ -724,7 +724,7 @@ XRE_RunAppShell()
       // run], because it's not aware that MessagePump has work that
       // needs to be processed; that was supposed to be signaled by
       // nsIRunnable(s).
-      // 
+      //
       // So instead of hacking Cocoa nsAppShell or rewriting the
       // event-loop system, we compromise here by processing any tasks
       // that might have been enqueued on MessagePump, *before*

--- a/xpcom/build/nsXULAppAPI.h
+++ b/xpcom/build/nsXULAppAPI.h
@@ -494,4 +494,9 @@ XRE_API(void,
 XRE_API(int,
         XRE_XPCShellMain, (int argc, char** argv, char** envp))
 
+#if MOZ_WIDGET_GTK == 2
+XRE_API(void,
+        XRE_GlibInit, ())
+#endif
+
 #endif // _nsXULAppAPI_h__

--- a/xpcom/glue/standalone/Makefile.in
+++ b/xpcom/glue/standalone/Makefile.in
@@ -6,3 +6,6 @@
 DIST_INSTALL	= 1
 # Force to build a static library only
 NO_EXPAND_LIBS = 1
+
+if CONFIG['MOZ_WIDGET_TOOLKIT'] in ('gtk2', 'gtk3'):
+    CXXFLAGS += CONFIG['GLIB_CFLAGS']

--- a/xpcom/glue/standalone/nsXPCOMGlue.cpp
+++ b/xpcom/glue/standalone/nsXPCOMGlue.cpp
@@ -431,7 +431,6 @@ XPCOMGlueEnablePreload()
 #endif
 
 ifdef MOZ_GSLICE_INIT
-#include <glib.h>
 
 class GSliceInit {
 public:

--- a/xpcom/glue/standalone/nsXPCOMGlue.cpp
+++ b/xpcom/glue/standalone/nsXPCOMGlue.cpp
@@ -430,7 +430,7 @@ XPCOMGlueEnablePreload()
 #define MOZ_GSLICE_INIT
 #endif
 
-ifdef MOZ_GSLICE_INIT
+#ifdef MOZ_GSLICE_INIT
 
 class GSliceInit {
 public:

--- a/xpcom/glue/standalone/nsXPCOMGlue.cpp
+++ b/xpcom/glue/standalone/nsXPCOMGlue.cpp
@@ -426,9 +426,55 @@ XPCOMGlueEnablePreload()
   do_preload = true;
 }
 
+#if defined(MOZ_WIDGET_GTK) && (defined(MOZ_MEMORY) || defined(__FreeBSD__) || defined(__NetBSD__))
+#define MOZ_GSLICE_INIT
+#endif
+
+ifdef MOZ_GSLICE_INIT
+#include <glib.h>
+
+class GSliceInit {
+public:
+  GSliceInit() {
+    mHadGSlice = bool(getenv("G_SLICE"));
+    if (!mHadGSlice) {
+      // Disable the slice allocator, since jemalloc already uses similar layout
+      // algorithms, and using a sub-allocator tends to increase fragmentation.
+      // This must be done before g_thread_init() is called.
+      // GLib >= 2.36 initializes g_slice as a side effect of its various static
+      // initializers, so this needs to happen before GLib is loaded, which is
+      // this is hooked in XPCOMGlueStartup before libxul is loaded. This
+      // relies on the main executable not depending on GLib.
+      setenv("G_SLICE", "always-malloc", 1);
+    }
+  }
+
+  ~GSliceInit() {
+#if MOZ_WIDGET_GTK == 2
+    if (sTop) {
+      auto XRE_GlibInit = (void (*)(void)) GetSymbol(sTop->libHandle,
+        "XRE_GlibInit");
+      // Initialize GLib enough for G_SLICE to have an effect before it is unset.
+      // unset.
+      XRE_GlibInit();
+    }
+#endif
+    if (!mHadGSlice) {
+      unsetenv("G_SLICE");
+    }
+  }
+
+private:
+  bool mHadGSlice;
+};
+#endif
+
 nsresult
 XPCOMGlueStartup(const char* aXPCOMFile)
 {
+#ifdef MOZ_GSLICE_INIT
+  GSliceInit gSliceInit;
+#endif
   xpcomFunctions.version = XPCOM_GLUE_VERSION;
   xpcomFunctions.size    = sizeof(XPCOMFunctions);
 


### PR DESCRIPTION
Re-lands fix for un-highlighting  highlighted text when the find bar is closed.

Re-lands patch for using default locale as fallback for add-on metadata.

Re-lands fix for annoying "Critical" GLib message on start-up when using jemalloc.

Confirmed that all three are working as intended.