### PR TITLE
Few more fixes ported from current codebase

### DIFF
--- a/build/unix/stdc++compat/stdc++compat.cpp
+++ b/build/unix/stdc++compat/stdc++compat.cpp
@@ -22,28 +22,16 @@
    GLIBCXX_3.4.18 is from gcc 4.8.0 (190787)
    GLIBCXX_3.4.19 is from gcc 4.8.1 (199309)
    GLIBCXX_3.4.20 is from gcc 4.9.0 (199307)
-   GLIBCXX_3.4.21 is from gcc 5.0 (210290) */
+   GLIBCXX_3.4.21 is from gcc 5.0 (210290)
+
+This file adds the necessary compatibility tricks to avoid symbols with
+version GLIBCXX_3.4.11 and bigger, keeping binary compatibility with
+libstdc++ 4.3.
+*/
 
 #define GLIBCXX_VERSION(a, b, c) (((a) << 16) | ((b) << 8) | (c))
 
 namespace std {
-#if MOZ_LIBSTDCXX_VERSION >= GLIBCXX_VERSION(3, 4, 9)
-    /* Instantiate these templates to avoid GLIBCXX_3.4.9 symbol versions */
-    template ostream& ostream::_M_insert(double);
-    template ostream& ostream::_M_insert(long);
-    template ostream& ostream::_M_insert(unsigned long);
-    template ostream& ostream::_M_insert(long long);
-    template ostream& ostream::_M_insert(unsigned long long);
-    template ostream& ostream::_M_insert(bool);
-    template ostream& ostream::_M_insert(const void*);
-    template ostream& __ostream_insert(ostream&, const char*, streamsize);
-    template istream& istream::_M_extract(double&);
-    template istream& istream::_M_extract(float&);
-    template istream& istream::_M_extract(unsigned int&);
-    template istream& istream::_M_extract(unsigned long&);
-    template istream& istream::_M_extract(unsigned short&);
-    template istream& istream::_M_extract(unsigned long long&);
-#endif
 #if MOZ_LIBSTDCXX_VERSION >= GLIBCXX_VERSION(3, 4, 14)
     /* Instantiate these templates to avoid GLIBCXX_3.4.14 symbol versions
      * depending on optimization level */

--- a/build/unix/stdc++compat/stdc++compat.cpp
+++ b/build/unix/stdc++compat/stdc++compat.cpp
@@ -21,7 +21,8 @@
    GLIBCXX_3.4.17 is from gcc 4.7.0 (174383)
    GLIBCXX_3.4.18 is from gcc 4.8.0 (190787)
    GLIBCXX_3.4.19 is from gcc 4.8.1 (199309)
-   GLIBCXX_3.4.20 is from gcc 4.9.0 (199307) */
+   GLIBCXX_3.4.20 is from gcc 4.9.0 (199307)
+   GLIBCXX_3.4.21 is from gcc 5.0 (210290) */
 
 #define GLIBCXX_VERSION(a, b, c) (((a) << 16) | ((b) << 8) | (c))
 
@@ -59,9 +60,14 @@ namespace std {
     template wstring& wstring::assign(wstring&&);
 #endif /* __GXX_EXPERIMENTAL_CXX0X__ */
 #endif /* (__GNUC__ == 4) && (__GNUC_MINOR__ >= 5) */
+#if MOZ_LIBSTDCXX_VERSION >= GLIBCXX_VERSION(3, 4, 16)
+    /* Instantiate these templates to avoid GLIBCXX_3.4.16 symbol versions
+	 * depending on compiler optimizations */
+	template int string::_S_compare(size_type, size_type);
+#endif
 }
 
-namespace std __attribute__((visibility("default"))) {
+namespace std MOZ_EXPORT {
 #if MOZ_LIBSTDCXX_VERSION >= GLIBCXX_VERSION(3, 4, 14)
     /* Hack to avoid GLIBCXX_3.4.14 symbol versions */
     struct _List_node_base
@@ -174,5 +180,18 @@ extern "C" void
 __cxa_throw_bad_array_new_length()
 {
     MOZ_CRASH();
+}
+#endif
+
+#if MOZ_LIBSTDCXX_VERSION >= GLIBCXX_VERSION(3, 4, 21)
+/* While we generally don't build with exceptions, we have some host tools
+* that do use them. libstdc++ from GCC 5.0 added exception constructors with
+* char const* argument. Older versions only have a constructor with
+* std::string. */
+namespace std {
+	runtime_error::runtime_error(char const* s)
+	: runtime_error(std::string(s))
+	{
+	}
 }
 #endif

--- a/chrome/nsChromeRegistryChrome.cpp
+++ b/chrome/nsChromeRegistryChrome.cpp
@@ -947,6 +947,29 @@ nsChromeRegistryChrome::ManifestOverride(ManifestProcessingContext& cx, int line
     return;
   }
 
+  if (cx.mType == NS_SKIN_LOCATION) {
+	bool chromeSkinOnly = false;
+	nsresult rv = chromeuri->SchemeIs("chrome", &chromeSkinOnly);
+	chromeSkinOnly = chromeSkinOnly && NS_SUCCEEDED(rv);
+	if (chromeSkinOnly) {
+	  rv = resolveduri->SchemeIs("chrome", &chromeSkinOnly);
+	  chromeSkinOnly = chromeSkinOnly && NS_SUCCEEDED(rv);
+	}
+	if (chromeSkinOnly) {
+	  nsAutoCString chromePath, resolvedPath;
+	  chromeuri->GetPath(chromePath);
+	  resolveduri->GetPath(resolvedPath);
+	  chromeSkinOnly = StringBeginsWith(chromePath, NS_LITERAL_CSTRING("/skin/")) &&
+	                   StringBeginsWith(resolvedPath, NS_LITERAL_CSTRING("/skin/"));
+	}
+	if (!chromeSkinOnly) {
+	  LogMessageWithContext(cx.GetManifestURI(), lineno, nsIScriptError::warningFlag,
+	                        "Cannot register non-chrome://.../skin/ URIs '%s' and '%s' as overrides and/or to be overridden from a skin manifest.",
+							chrome, resolved);
+	  return;
+	}
+  }
+
   if (!CanLoadResource(resolveduri)) {
     LogMessageWithContext(cx.GetManifestURI(), lineno, nsIScriptError::warningFlag,
                           "Cannot register non-local URI '%s' for an override.", resolved);

--- a/config/config.mk
+++ b/config/config.mk
@@ -655,7 +655,7 @@ EXPAND_MKSHLIB = $(EXPAND_LIBS_EXEC) $(EXPAND_MKSHLIB_ARGS) -- $(MKSHLIB)
 
 ifneq (,$(MOZ_LIBSTDCXX_TARGET_VERSION)$(MOZ_LIBSTDCXX_HOST_VERSION))
 ifneq ($(OS_ARCH),Darwin)
-CHECK_STDCXX = @$(TOOLCHAIN_PREFIX)objdump -p $(1) | grep -v -e 'GLIBCXX_3\.4\.\(9\|[1-9][0-9]\)' > /dev/null || ( echo 'TEST-UNEXPECTED-FAIL | check_stdcxx | We do not want these libstdc++ symbols to be used:' && $(TOOLCHAIN_PREFIX)objdump -T $(1) | grep -e 'GLIBCXX_3\.4\.\(9\|[1-9][0-9]\)' && false)
+CHECK_STDCXX = @$(TOOLCHAIN_PREFIX)objdump -p $(1) | grep -e 'GLIBCXX_3\.4\.\(1[1-9]\|[2-9][0-9]\)' > /dev/null && echo 'TEST-UNEXPECTED-FAIL | check_stdcxx | We do not want these libstdc++ symbols to be used:' && $(TOOLCHAIN_PREFIX)objdump -T $(1) | grep -e 'GLIBCXX_3\.4\.\(1[1-9]\|[2-9][0-9]\)' && exit 1 || true
 endif
 endif
 

--- a/config/rules.mk
+++ b/config/rules.mk
@@ -715,6 +715,9 @@ else
 	$(EXPAND_LIBS_EXEC) -- $(HOST_CC) -o $@ $(HOST_CFLAGS) $(HOST_LDFLAGS) $(HOST_PROGOBJS) $(HOST_LIBS) $(HOST_EXTRA_LIBS)
 endif # HOST_CPP_PROG_LINK
 endif
+ifndef CROSS_COMPILE
+       $(call CHECK_STDCXX,$@)
+endif
 
 #
 # This is an attempt to support generation of multiple binaries
@@ -756,6 +759,9 @@ ifneq (,$(HOST_CPPSRCS)$(USE_HOST_CXX))
 else
 	$(EXPAND_LIBS_EXEC) -- $(HOST_CC) $(HOST_OUTOPTION)$@ $(HOST_CFLAGS) $(INCLUDES) $< $(HOST_LIBS) $(HOST_EXTRA_LIBS)
 endif
+endif
+ifndef CROSS_COMPILE
+       $(call CHECK_STDCXX,$@)
 endif
 
 ifdef DTRACE_PROBE_OBJ
@@ -801,6 +807,9 @@ $(DTRACE_PROBE_OBJ): $(NON_DTRACE_OBJS)
 endif
 endif
 endif
+endif
+ifndef CROSS_COMPILE
+       $(call CHECK_STDCXX,$@)
 endif
 
 # On Darwin (Mac OS X), dwarf2 debugging uses debug info left in .o files,

--- a/config/rules.mk
+++ b/config/rules.mk
@@ -808,9 +808,6 @@ endif
 endif
 endif
 endif
-ifndef CROSS_COMPILE
-       $(call CHECK_STDCXX,$@)
-endif
 
 # On Darwin (Mac OS X), dwarf2 debugging uses debug info left in .o files,
 # so instead of deleting .o files after repacking them into a dylib, we make

--- a/js/src/jsnum.h
+++ b/js/src/jsnum.h
@@ -14,6 +14,21 @@
 
 #include "js/Conversions.h"
 
+// This macro should be "1" if the compiler being used supports built-in
+// functions like __builtin_sadd_overflow.
+#if __GNUC__ >= 5
+    // GCC 5 and above supports these functions.
+	#define BUILTIN_CHECKED_ARITHMETIC_SUPPORTED(x) 1
+#else
+	// For CLANG, we can use its own function to check for this.
+    #ifdef __has_builtin
+	    #define BUILTIN_CHECKED_ARITHMETIC_SUPPORTED(x) __has_builtin(x)
+	#endif
+#endif
+#ifndef BUILTIN_CHECKED_ARITHMETIC_SUPPORTED
+    #define BUILTIN_CHECKED_ARITHMETIC_SUPPORTED(x) 0
+#endif
+
 namespace js {
 
 class StringBuffer;
@@ -262,27 +277,40 @@ bool ToLengthClamped(T* cx, HandleValue v, uint32_t* out, bool* overflow);
 inline bool
 SafeAdd(int32_t one, int32_t two, int32_t* res)
 {
+#if BUILTIN_CHECKED_ARITHMETIC_SUPPORTED(__builtin_sadd_overflow)
+    // Use the compiler's builtin function.
+	return !__builtin_sadd_overflow(one, two, res);
+#else
     // Use unsigned for the 32-bit operation since signed overflow gets
     // undefined behavior.
     *res = uint32_t(one) + uint32_t(two);
     int64_t ores = (int64_t)one + (int64_t)two;
     return ores == (int64_t)*res;
+#endif
 }
 
 inline bool
 SafeSub(int32_t one, int32_t two, int32_t* res)
 {
+#if BUILTIN_CHECKED_ARITHMETIC_SUPPORTED(__builtin_ssub_overflow)
+    return !__builtin_ssub_overflow(one, two, res);
+#else
     *res = uint32_t(one) - uint32_t(two);
     int64_t ores = (int64_t)one - (int64_t)two;
     return ores == (int64_t)*res;
+#endif
 }
 
 inline bool
 SafeMul(int32_t one, int32_t two, int32_t* res)
 {
+#if BUILTIN_CHECKED_ARITHMETIC_SUPPORTED(__builtin_smul_overflow)
+    return !__builtin_smul_overflow(one, two, res);
+#else
     *res = uint32_t(one) * uint32_t(two);
     int64_t ores = (int64_t)one * (int64_t)two;
     return ores == (int64_t)*res;
+#endif
 }
 
 extern bool

--- a/xpcom/components/ManifestParser.cpp
+++ b/xpcom/components/ManifestParser.cpp
@@ -131,8 +131,9 @@ static const ManifestDirective kParsingTable[] = {
     "style",            2, false, true, false, false,
     nullptr, &nsChromeRegistry::ManifestStyle, nullptr
   },
-  {
-    "override",         2, true, true, true, false,
+  { // NB: note that while skin manifests can use this, they are only allowed
+    // to use it for chrome://../skin/ URLs
+    "override",         2, false, true, true, false,
     nullptr, &nsChromeRegistry::ManifestOverride, nullptr
   },
   {


### PR DESCRIPTION
Re-lands fix allowing chrome://../skin/ overrides
Re-lands patch bumping minimum supported libstdc++ to v4.3
Re-lands stdc++ compat checks for GCC
Re-lands patch to allow supported compilers (GCC >= 5.x & some versions of Clang) to use their built-in overflow-checked functions

Tested and confirmed working.