### PR TITLE
Compiler updates

### DIFF
--- a/gfx/angle/moz.build
+++ b/gfx/angle/moz.build
@@ -89,11 +89,21 @@ SOURCES += [
 if CONFIG['GNU_CXX']:
     CXXFLAGS += [
         '-Wno-attributes',
+        '-Wno-shadow',
         '-Wno-sign-compare',
         '-Wno-unknown-pragmas',
+        '-Wno-unreachable-code',
     ]
     if CONFIG['CLANG_CXX']:
-        CXXFLAGS += ['-Wno-unused-private-field']
+        CXXFLAGS += [
+            '-Wno-inconsistent-missing-override',
+            '-Wno-unused-private-field',
+        ]
+    else:
+        CXXFLAGS += [
+            '-Wno-shadow-compatible-local',
+            '-Wno-shadow-local',
+        ]
 
 if CONFIG['MOZ_DIRECTX_SDK_PATH'] and not CONFIG['MOZ_HAS_WINSDK_WITH_D3D']:
     CXXFLAGS += ['-I\'%s/include/\'' % CONFIG['MOZ_DIRECTX_SDK_PATH']]

--- a/gfx/angle/moz.build
+++ b/gfx/angle/moz.build
@@ -94,15 +94,15 @@ if CONFIG['GNU_CXX']:
         '-Wno-unknown-pragmas',
         '-Wno-unreachable-code',
     ]
-    if CONFIG['CLANG_CXX']:
+if CONFIG['GNU_CXX'] and not CONFIG['CLANG_CXX']:
+    CXXFLAGS += [
+	    '-Wno-shadow-compatible-local',
+		'-Wno-shadow-local',
+	]
+if CONFIG['CLANG_CXX']:
         CXXFLAGS += [
             '-Wno-inconsistent-missing-override',
             '-Wno-unused-private-field',
-        ]
-    else:
-        CXXFLAGS += [
-            '-Wno-shadow-compatible-local',
-            '-Wno-shadow-local',
         ]
 
 if CONFIG['MOZ_DIRECTX_SDK_PATH'] and not CONFIG['MOZ_HAS_WINSDK_WITH_D3D']:

--- a/gfx/angle/moz.build
+++ b/gfx/angle/moz.build
@@ -85,7 +85,7 @@ SOURCES += [
     'src/compiler/translator/glslang_tab.cpp',
 ]
 
-
+# Suppress warnings in third-party code.
 if CONFIG['GNU_CXX']:
     CXXFLAGS += [
         '-Wno-attributes',
@@ -94,16 +94,11 @@ if CONFIG['GNU_CXX']:
         '-Wno-unknown-pragmas',
         '-Wno-unreachable-code',
     ]
-if CONFIG['GNU_CXX'] and not CONFIG['CLANG_CXX']:
-    CXXFLAGS += [
-	    '-Wno-shadow-compatible-local',
-		'-Wno-shadow-local',
-	]
 if CONFIG['CLANG_CXX']:
-        CXXFLAGS += [
-            '-Wno-inconsistent-missing-override',
-            '-Wno-unused-private-field',
-        ]
+    CXXFLAGS += [
+        '-Wno-inconsistent-missing-override',
+        '-Wno-unused-private-field',
+    ]
 
 if CONFIG['MOZ_DIRECTX_SDK_PATH'] and not CONFIG['MOZ_HAS_WINSDK_WITH_D3D']:
     CXXFLAGS += ['-I\'%s/include/\'' % CONFIG['MOZ_DIRECTX_SDK_PATH']]

--- a/gfx/angle/src/libEGL/moz.build
+++ b/gfx/angle/src/libEGL/moz.build
@@ -21,11 +21,21 @@ UNIFIED_SOURCES += [
 if CONFIG['GNU_CXX']:
     CXXFLAGS += [
         '-Wno-attributes',
+        '-Wno-shadow',
         '-Wno-sign-compare',
         '-Wno-unknown-pragmas',
+        '-Wno-unreachable-code',
     ]
     if CONFIG['CLANG_CXX']:
-        CXXFLAGS += ['-Wno-unused-private-field']
+        CXXFLAGS += [
+            '-Wno-inconsistent-missing-override',
+            '-Wno-unused-private-field',
+        ]
+    else:
+        CXXFLAGS += [
+            '-Wno-shadow-compatible-local',
+            '-Wno-shadow-local',
+        ]
 
 if CONFIG['MOZ_DIRECTX_SDK_PATH'] and not CONFIG['MOZ_HAS_WINSDK_WITH_D3D']:
     CXXFLAGS += ['-I\'%s/include/\'' % CONFIG['MOZ_DIRECTX_SDK_PATH']]

--- a/gfx/angle/src/libEGL/moz.build
+++ b/gfx/angle/src/libEGL/moz.build
@@ -26,11 +26,6 @@ if CONFIG['GNU_CXX']:
         '-Wno-unknown-pragmas',
         '-Wno-unreachable-code',
     ]
-if CONFIG['GNU_CXX'] and not CONFIG['CLANG_CXX']:
-    CXXFLAGS += [
-        '-Wno-shadow-compatible-local',
-        '-Wno-shadow-local',
-    ]
 if CONFIG['CLANG_CXX']:
     CXXFLAGS += [
         '-Wno-inconsistent-missing-override',

--- a/gfx/angle/src/libEGL/moz.build
+++ b/gfx/angle/src/libEGL/moz.build
@@ -17,7 +17,7 @@ UNIFIED_SOURCES += [
     'Surface.cpp',
 ]
 
-
+# Suppress warnings in third-party code.
 if CONFIG['GNU_CXX']:
     CXXFLAGS += [
         '-Wno-attributes',
@@ -26,16 +26,16 @@ if CONFIG['GNU_CXX']:
         '-Wno-unknown-pragmas',
         '-Wno-unreachable-code',
     ]
-    if CONFIG['CLANG_CXX']:
-        CXXFLAGS += [
-            '-Wno-inconsistent-missing-override',
-            '-Wno-unused-private-field',
-        ]
-    else:
-        CXXFLAGS += [
-            '-Wno-shadow-compatible-local',
-            '-Wno-shadow-local',
-        ]
+if CONFIG['GNU_CXX'] and not CONFIG['CLANG_CXX']:
+    CXXFLAGS += [
+        '-Wno-shadow-compatible-local',
+        '-Wno-shadow-local',
+    ]
+if CONFIG['CLANG_CXX']:
+    CXXFLAGS += [
+        '-Wno-inconsistent-missing-override',
+        '-Wno-unused-private-field',
+    ]
 
 if CONFIG['MOZ_DIRECTX_SDK_PATH'] and not CONFIG['MOZ_HAS_WINSDK_WITH_D3D']:
     CXXFLAGS += ['-I\'%s/include/\'' % CONFIG['MOZ_DIRECTX_SDK_PATH']]

--- a/gfx/angle/src/libGLESv2/moz.build
+++ b/gfx/angle/src/libGLESv2/moz.build
@@ -189,11 +189,6 @@ if CONFIG['GNU_CXX']:
         '-Wno-unknown-pragmas',
         '-Wno-unreachable-code',
     ]
-if CONFIG['GNU_CXX'] and not CONFIG['CLANG_CXX']:
-    CXXFLAGS += [
-        '-Wno-shadow-compatible-local',
-        '-Wno-shadow-local',
-    ]
 if CONFIG['CLANG_CXX']:
     CXXFLAGS += [
         '-Wno-inconsistent-missing-override',

--- a/gfx/angle/src/libGLESv2/moz.build
+++ b/gfx/angle/src/libGLESv2/moz.build
@@ -184,11 +184,21 @@ if CONFIG['MOZ_HAS_WINSDK_WITH_D3D']:
 if CONFIG['GNU_CXX']:
     CXXFLAGS += [
         '-Wno-attributes',
+        '-Wno-shadow',
         '-Wno-sign-compare',
         '-Wno-unknown-pragmas',
+        '-Wno-unreachable-code',
     ]
     if CONFIG['CLANG_CXX']:
-        CXXFLAGS += ['-Wno-unused-private-field']
+        CXXFLAGS += [
+            '-Wno-inconsistent-missing-override',
+            '-Wno-unused-private-field',
+        ]
+    else:
+        CXXFLAGS += [
+            '-Wno-shadow-compatible-local',
+            '-Wno-shadow-local',
+        ]
 
 if CONFIG['MOZ_DIRECTX_SDK_PATH'] and not CONFIG['MOZ_HAS_WINSDK_WITH_D3D']:
     CXXFLAGS += ['-I\'%s/include/\'' % CONFIG['MOZ_DIRECTX_SDK_PATH']]

--- a/gfx/angle/src/libGLESv2/moz.build
+++ b/gfx/angle/src/libGLESv2/moz.build
@@ -180,7 +180,7 @@ if CONFIG['MOZ_HAS_WINSDK_WITH_D3D']:
         'renderer/d3d/d3d11/SwapChain11.cpp',
     ]
 
-
+# Suppress warnings in third-party code.
 if CONFIG['GNU_CXX']:
     CXXFLAGS += [
         '-Wno-attributes',
@@ -189,16 +189,16 @@ if CONFIG['GNU_CXX']:
         '-Wno-unknown-pragmas',
         '-Wno-unreachable-code',
     ]
-    if CONFIG['CLANG_CXX']:
-        CXXFLAGS += [
-            '-Wno-inconsistent-missing-override',
-            '-Wno-unused-private-field',
-        ]
-    else:
-        CXXFLAGS += [
-            '-Wno-shadow-compatible-local',
-            '-Wno-shadow-local',
-        ]
+if CONFIG['GNU_CXX'] and not CONFIG['CLANG_CXX']:
+    CXXFLAGS += [
+        '-Wno-shadow-compatible-local',
+        '-Wno-shadow-local',
+    ]
+if CONFIG['CLANG_CXX']:
+    CXXFLAGS += [
+        '-Wno-inconsistent-missing-override',
+        '-Wno-unused-private-field',
+    ]
 
 if CONFIG['MOZ_DIRECTX_SDK_PATH'] and not CONFIG['MOZ_HAS_WINSDK_WITH_D3D']:
     CXXFLAGS += ['-I\'%s/include/\'' % CONFIG['MOZ_DIRECTX_SDK_PATH']]

--- a/gfx/cairo/cairo/src/moz.build
+++ b/gfx/cairo/cairo/src/moz.build
@@ -216,12 +216,13 @@ if CONFIG['GNU_CC']:
         '-Wno-missing-field-initializers',
         '-Wno-conversion',
     ]
-    if CONFIG['CLANG_CXX']:
-        CFLAGS += [
-            '-Wno-incompatible-pointer-types',
-            '-Wno-tautological-compare',
-            '-Wno-tautological-constant-out-of-range-compare',
-        ]
+if CONFIG['CLANG_CXX']:
+    CFLAGS += [
+        '-Wno-incompatible-pointer-types',
+        '-Wno-tautological-compare',
+        '-Wno-tautological-constant-out-of-range-compare',
+        '-Wno-error=uninitialized',
+    ]
 
 if CONFIG['MOZ_WIDGET_TOOLKIT'] == 'qt':
     CFLAGS += CONFIG['MOZ_QT_CFLAGS']

--- a/gfx/cairo/libpixman/src/moz.build
+++ b/gfx/cairo/libpixman/src/moz.build
@@ -140,10 +140,11 @@ if CONFIG['GNU_CC']:
         '-Wno-address',
         '-Wno-sign-compare',
         '-Wno-missing-field-initializers',
+		'-Wno-unused',
     ]
-    if CONFIG['CLANG_CXX']:
-        CFLAGS += [
-            '-Wno-incompatible-pointer-types',
-            '-Wno-tautological-compare',
-            '-Wno-tautological-constant-out-of-range-compare',
-        ]
+if CONFIG['CLANG_CXX']:
+    CFLAGS += [
+        '-Wno-incompatible-pointer-types',
+        '-Wno-tautological-compare',
+        '-Wno-tautological-constant-out-of-range-compare',
+    ]

--- a/gfx/skia/generate_mozbuild.py
+++ b/gfx/skia/generate_mozbuild.py
@@ -138,7 +138,9 @@ if CONFIG['GNU_CXX']:
         '-Wno-overloaded-virtual',
         '-Wno-unused-function',
     ]
-    if not CONFIG['CLANG_CXX']:
+    if CONFIG['CLANG_CXX']:
+        CXXFLAGS += ['-Wno-inconsistent-missing-override']
+    else:
         CXXFLAGS += ['-Wno-logical-op']
     if CONFIG['CPU_ARCH'] == 'arm':
         SOURCES['trunk/src/opts/SkBlitRow_opts_arm.cpp'].flags += ['-fomit-frame-pointer']

--- a/gfx/skia/generate_mozbuild.py
+++ b/gfx/skia/generate_mozbuild.py
@@ -137,9 +137,14 @@ if CONFIG['GNU_CXX']:
     CXXFLAGS += [
         '-Wno-overloaded-virtual',
         '-Wno-unused-function',
+        '-Wno-deprecated-declarations',
     ]
     if CONFIG['CLANG_CXX']:
-        CXXFLAGS += ['-Wno-inconsistent-missing-override']
+        CXXFLAGS += [
+            '-Wno-inconsistent-missing-override',
+            '-Wno-macro-redefined',
+            '-Wno-unused-private-field',
+        ]
     else:
         CXXFLAGS += ['-Wno-logical-op']
     if CONFIG['CPU_ARCH'] == 'arm':

--- a/gfx/skia/generate_mozbuild.py
+++ b/gfx/skia/generate_mozbuild.py
@@ -130,9 +130,13 @@ elif CONFIG['CLANG_CL']:
     SOURCES['trunk/src/opts/SkBitmapProcState_opts_SSSE3.cpp'].flags += ['-mssse3']
     SOURCES['trunk/src/opts/SkBlurImage_opts_SSE4.cpp'].flags += ['-msse4.1']
 
+if CONFIG['GNU_CXX'] and CONFIG['CPU_ARCH'] == 'arm':
+    SOURCES['skia/src/opts/SkBlitRow_opts_arm.cpp'].flags += ['-fomit-frame-pointer']
+
 DEFINES['SKIA_IMPLEMENTATION'] = 1
 DEFINES['GR_IMPLEMENTATION'] = 1
 
+# Suppress warnings in third-party code.
 if CONFIG['GNU_CXX']:
     CXXFLAGS += [
         '-Wno-deprecated-declarations',
@@ -140,20 +144,18 @@ if CONFIG['GNU_CXX']:
         '-Wno-sign-compare',
         '-Wno-unused-function',
     ]
-    if CONFIG['CLANG_CXX']:
+if CONFIG['GNU_CXX'] and not CONFIG['CLANG_CXX']:
+    CXXFLAGS += [
+	    '-Wno-logical-op',
+		'-Wno-maybe-uninitialized',
+	]
+if CONFIG['CLANG_CXX']:
         CXXFLAGS += [
             '-Wno-implicit-fallthrough',
             '-Wno-inconsistent-missing-override',
             '-Wno-macro-redefined',
             '-Wno-unused-private-field',
         ]
-    else:
-        CXXFLAGS += [
-            '-Wno-logical-op',
-            '-Wno-maybe-uninitialized',
-        ]
-    if CONFIG['CPU_ARCH'] == 'arm':
-        SOURCES['trunk/src/opts/SkBlitRow_opts_arm.cpp'].flags += ['-fomit-frame-pointer']
 
 if CONFIG['MOZ_WIDGET_TOOLKIT'] in ('gtk2', 'gtk3', 'android', 'gonk', 'qt'):
     CXXFLAGS += CONFIG['MOZ_CAIRO_CFLAGS']

--- a/gfx/skia/generate_mozbuild.py
+++ b/gfx/skia/generate_mozbuild.py
@@ -137,10 +137,11 @@ if CONFIG['GNU_CXX']:
     CXXFLAGS += [
         '-Wno-overloaded-virtual',
         '-Wno-unused-function',
-        '-fomit-frame-pointer',
     ]
     if not CONFIG['CLANG_CXX']:
         CXXFLAGS += ['-Wno-logical-op']
+    if CONFIG['CPU_ARCH'] == 'arm':
+        SOURCES['trunk/src/opts/SkBlitRow_opts_arm.cpp'].flags += ['-fomit-frame-pointer']
 
 if CONFIG['MOZ_WIDGET_TOOLKIT'] in ('gtk2', 'gtk3', 'android', 'gonk', 'qt'):
     CXXFLAGS += CONFIG['MOZ_CAIRO_CFLAGS']
@@ -359,6 +360,7 @@ def write_sources(f, values, indent):
     'SkBlitter_ARGB32.cpp',
     'SkBlitter_RGB16.cpp',
     'SkBlitter_Sprite.cpp',
+    'SkBlitRow_opts_arm.cpp',
     'SkScan_Antihair.cpp',
     'SkCondVar.cpp',
     'SkParse.cpp',

--- a/gfx/skia/generate_mozbuild.py
+++ b/gfx/skia/generate_mozbuild.py
@@ -135,18 +135,23 @@ DEFINES['GR_IMPLEMENTATION'] = 1
 
 if CONFIG['GNU_CXX']:
     CXXFLAGS += [
-        '-Wno-overloaded-virtual',
-        '-Wno-unused-function',
         '-Wno-deprecated-declarations',
+        '-Wno-overloaded-virtual',
+        '-Wno-sign-compare',
+        '-Wno-unused-function',
     ]
     if CONFIG['CLANG_CXX']:
         CXXFLAGS += [
+            '-Wno-implicit-fallthrough',
             '-Wno-inconsistent-missing-override',
             '-Wno-macro-redefined',
             '-Wno-unused-private-field',
         ]
     else:
-        CXXFLAGS += ['-Wno-logical-op']
+        CXXFLAGS += [
+            '-Wno-logical-op',
+            '-Wno-maybe-uninitialized',
+        ]
     if CONFIG['CPU_ARCH'] == 'arm':
         SOURCES['trunk/src/opts/SkBlitRow_opts_arm.cpp'].flags += ['-fomit-frame-pointer']
 

--- a/gfx/skia/moz.build
+++ b/gfx/skia/moz.build
@@ -816,12 +816,14 @@ elif CONFIG['CPU_ARCH'] == 'arm' and CONFIG['GNU_CC']:
         'trunk/src/core/SkUtilsArm.cpp',
         'trunk/src/opts/SkBitmapProcState_opts_arm.cpp',
         'trunk/src/opts/SkBlitMask_opts_arm.cpp',
-        'trunk/src/opts/SkBlitRow_opts_arm.cpp',
         'trunk/src/opts/SkBlurImage_opts_arm.cpp',
         'trunk/src/opts/SkMorphology_opts_arm.cpp',
         'trunk/src/opts/SkTextureCompression_opts_arm.cpp',
         'trunk/src/opts/SkUtils_opts_arm.cpp',
         'trunk/src/opts/SkXfermode_opts_arm.cpp',
+    ]
+    SOURCES += [
+        'trunk/src/opts/SkBlitRow_opts_arm.cpp',
     ]
     if CONFIG['BUILD_ARM_NEON']:
         SOURCES += [
@@ -965,10 +967,11 @@ if CONFIG['GNU_CXX']:
     CXXFLAGS += [
         '-Wno-overloaded-virtual',
         '-Wno-unused-function',
-        '-fomit-frame-pointer',
     ]
     if not CONFIG['CLANG_CXX']:
         CXXFLAGS += ['-Wno-logical-op']
+    if CONFIG['CPU_ARCH'] == 'arm':
+        SOURCES['trunk/src/opts/SkBlitRow_opts_arm.cpp'].flags += ['-fomit-frame-pointer']
 
 if CONFIG['MOZ_WIDGET_TOOLKIT'] in ('gtk2', 'gtk3', 'android', 'gonk', 'qt'):
     CXXFLAGS += CONFIG['MOZ_CAIRO_CFLAGS']

--- a/gfx/skia/moz.build
+++ b/gfx/skia/moz.build
@@ -965,18 +965,23 @@ DEFINES['GR_IMPLEMENTATION'] = 1
 
 if CONFIG['GNU_CXX']:
     CXXFLAGS += [
-        '-Wno-overloaded-virtual',
-        '-Wno-unused-function',
         '-Wno-deprecated-declarations',
+        '-Wno-overloaded-virtual',
+        '-Wno-sign-compare',
+        '-Wno-unused-function',
     ]
     if CONFIG['CLANG_CXX']:
         CXXFLAGS += [
+            '-Wno-implicit-fallthrough',
             '-Wno-inconsistent-missing-override',
             '-Wno-macro-redefined',
             '-Wno-unused-private-field',
         ]
     else:
-        CXXFLAGS += ['-Wno-logical-op']
+        CXXFLAGS += [
+            '-Wno-logical-op',
+            '-Wno-maybe-uninitialized',
+        ]
     if CONFIG['CPU_ARCH'] == 'arm':
         SOURCES['trunk/src/opts/SkBlitRow_opts_arm.cpp'].flags += ['-fomit-frame-pointer']
 

--- a/gfx/skia/moz.build
+++ b/gfx/skia/moz.build
@@ -967,9 +967,14 @@ if CONFIG['GNU_CXX']:
     CXXFLAGS += [
         '-Wno-overloaded-virtual',
         '-Wno-unused-function',
+        '-Wno-deprecated-declarations',
     ]
     if CONFIG['CLANG_CXX']:
-        CXXFLAGS += ['-Wno-inconsistent-missing-override']
+        CXXFLAGS += [
+            '-Wno-inconsistent-missing-override',
+            '-Wno-macro-redefined',
+            '-Wno-unused-private-field',
+        ]
     else:
         CXXFLAGS += ['-Wno-logical-op']
     if CONFIG['CPU_ARCH'] == 'arm':

--- a/gfx/skia/moz.build
+++ b/gfx/skia/moz.build
@@ -960,9 +960,13 @@ elif CONFIG['CLANG_CL']:
     SOURCES['trunk/src/opts/SkBitmapProcState_opts_SSSE3.cpp'].flags += ['-mssse3']
     SOURCES['trunk/src/opts/SkBlurImage_opts_SSE4.cpp'].flags += ['-msse4.1']
 
+if CONFIG['GNU_CXX'] and CONFIG['CPU_ARCH'] == 'arm':
+    SOURCES['skia/src/opts/SkBlitRow_opts_arm.cpp'].flags += ['-fomit-frame-pointer']
+
 DEFINES['SKIA_IMPLEMENTATION'] = 1
 DEFINES['GR_IMPLEMENTATION'] = 1
 
+# Suppress warnings in third-party code.
 if CONFIG['GNU_CXX']:
     CXXFLAGS += [
         '-Wno-deprecated-declarations',
@@ -970,20 +974,18 @@ if CONFIG['GNU_CXX']:
         '-Wno-sign-compare',
         '-Wno-unused-function',
     ]
-    if CONFIG['CLANG_CXX']:
-        CXXFLAGS += [
-            '-Wno-implicit-fallthrough',
-            '-Wno-inconsistent-missing-override',
-            '-Wno-macro-redefined',
-            '-Wno-unused-private-field',
-        ]
-    else:
-        CXXFLAGS += [
-            '-Wno-logical-op',
-            '-Wno-maybe-uninitialized',
-        ]
-    if CONFIG['CPU_ARCH'] == 'arm':
-        SOURCES['trunk/src/opts/SkBlitRow_opts_arm.cpp'].flags += ['-fomit-frame-pointer']
+if CONFIG['GNU_CXX'] and not CONFIG['CLANG_CXX']:
+    CXXFLAGS += [
+	    '-Wno-logical-op',
+		'-Wno-maybe-uninitialized',
+	]
+if CONFIG['CLANG_CXX']:
+    CXXFLAGS += [
+        '-Wno-implicit-fallthrough',
+        '-Wno-inconsistent-missing-override',
+        '-Wno-macro-redefined',
+        '-Wno-unused-private-field',
+    ]
 
 if CONFIG['MOZ_WIDGET_TOOLKIT'] in ('gtk2', 'gtk3', 'android', 'gonk', 'qt'):
     CXXFLAGS += CONFIG['MOZ_CAIRO_CFLAGS']

--- a/gfx/skia/moz.build
+++ b/gfx/skia/moz.build
@@ -968,7 +968,9 @@ if CONFIG['GNU_CXX']:
         '-Wno-overloaded-virtual',
         '-Wno-unused-function',
     ]
-    if not CONFIG['CLANG_CXX']:
+    if CONFIG['CLANG_CXX']:
+        CXXFLAGS += ['-Wno-inconsistent-missing-override']
+    else:
         CXXFLAGS += ['-Wno-logical-op']
     if CONFIG['CPU_ARCH'] == 'arm':
         SOURCES['trunk/src/opts/SkBlitRow_opts_arm.cpp'].flags += ['-fomit-frame-pointer']

--- a/media/libtheora/moz.build
+++ b/media/libtheora/moz.build
@@ -23,8 +23,8 @@ DEFINES['THEORA_DISABLE_ENCODE'] = True
 # Suppress warnings in third-party code.
 if CONFIG['GNU_CC']:
     CFLAGS += ['-Wno-type-limits']
-    if CONFIG['CLANG_CXX']:
-        CFLAGS += ['-Wno-tautological-compare']
+if CONFIG['CLANG_CXX']:
+    CFLAGS += ['-Wno-tautological-compare']
 
 UNIFIED_SOURCES += [
     'lib/apiwrapper.c',

--- a/media/libvpx/moz.build
+++ b/media/libvpx/moz.build
@@ -107,4 +107,7 @@ if CONFIG['CLANG_CL'] or not CONFIG['_MSC_VER']:
 
 # Suppress warnings in third-party code.
 if CONFIG['GNU_CC']:
-    CFLAGS += ['-Wno-sign-compare']
+    CFLAGS += [
+	    '-Wno-sign-compare',
+	    '-Wno-unused-function',
+	]


### PR DESCRIPTION
This PR silences several additional GCC and Clang warnings in 3rd party code (Skia, ANGLE, Cairo, libpixman, libtheora and libvpx).

Additionally, -fomit-frame-pointer is no longer used for all of Skia; just the one file that it needs to build.

Tested confirmed working with GCC 4.9 & 5.3. Clang has not (yet) been tested, but the changes made for it _should_ be fine.