### PR TITLE
Build with GStreamer 1.x support by default

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -5647,7 +5647,7 @@ WINNT|Darwin|Android)
     ;;
 *)
     MOZ_GSTREAMER=1
-    GST_API_VERSION=0.10
+    GST_API_VERSION=1.0
     ;;
 esac
 


### PR DESCRIPTION
This PR will automatically build with GStreamer 1.x support by default, regardless of whether --enable-gstreamer is found in the mozconfig. For those who don't want 1.x support, they can either use --enable-gstreamer=0.10 or --disable-gstreamer.

Tested & confirmed working as intended.