### PR TITLE
Use nsRefPtr for holding more references

### DIFF
--- a/dom/ipc/TabChild.cpp
+++ b/dom/ipc/TabChild.cpp
@@ -3066,7 +3066,7 @@ TabChild::DidComposite(uint64_t aTransactionId)
   MOZ_ASSERT(mWidget->GetLayerManager());
   MOZ_ASSERT(mWidget->GetLayerManager()->GetBackendType() == LayersBackend::LAYERS_CLIENT);
 
-  RefPtr<ClientLayerManager> manager =
+  nsRefPtr<ClientLayerManager> manager =
     static_cast<ClientLayerManager*>(mWidget->GetLayerManager());
     
   manager->DidComposite(aTransactionId);

--- a/gfx/layers/ipc/CompositorChild.cpp
+++ b/gfx/layers/ipc/CompositorChild.cpp
@@ -266,10 +266,10 @@ CompositorChild::RecvDidComposite(const uint64_t& aId, const uint64_t& aTransact
 {
   if (mLayerManager) {
     MOZ_ASSERT(aId == 0);
-    RefPtr<ClientLayerManager> m = mLayerManager;
+    nsRefPtr<ClientLayerManager> m = mLayerManager;
     m->DidComposite(aTransactionId);
   } else if (aId != 0) {
-    RefPtr<dom::TabChild> child = dom::TabChild::GetFrom(aId);
+    nsRefPtr<dom::TabChild> child = dom::TabChild::GetFrom(aId);
     if (child) {
       child->DidComposite(aTransactionId);
     }


### PR DESCRIPTION
This PR fixes build bustage on Linux as a result of commit d30f5a5.

Confirmed working with GCC 4.9