### PR TITLE
Reference counted class nsMacShellService should not have a public destructor

### DIFF
--- a/browser/components/shell/nsMacShellService.h
+++ b/browser/components/shell/nsMacShellService.h
@@ -16,7 +16,6 @@ class nsMacShellService : public nsIMacShellService,
 {
 public:
   nsMacShellService() : mCheckedThisSession(false) {};
-  virtual ~nsMacShellService() {};
 
   NS_DECL_ISUPPORTS
   NS_DECL_NSISHELLSERVICE
@@ -24,6 +23,7 @@ public:
   NS_DECL_NSIWEBPROGRESSLISTENER
 
 protected:
+  virtual ~nsMacShellService() {};
 
 private:
   nsCOMPtr<nsIFile> mBackgroundFile;


### PR DESCRIPTION
> 3:19.81 /Users/pale/jenkins/workspace/tycho/default/browser/components/shell/nsMacShellService.cpp:35:1: error: static_assert failed "Reference-counted class nsMacShellService should not have a public destructor. Try to make this class's destructor non-public. If that is really not possible, you can whitelist this class by providing a HasDangerousPublicDestructor specialization for it."

cc @mattatobin I confirmed this removes the error