### PR TITLE
SaveURI seems to now take a referrerPolicy, get from content

### DIFF
--- a/browser/components/shell/nsMacShellService.cpp
+++ b/browser/components/shell/nsMacShellService.cpp
@@ -202,8 +202,8 @@ nsMacShellService::SetDesktopBackground(nsIDOMElement* aElement,
     loadContext = do_QueryInterface(docShell);
   }
 
-  return wbp->SaveURI(imageURI, nullptr, docURI, nullptr, nullptr,
-                      mBackgroundFile, loadContext);
+  return wbp->SaveURI(imageURI, nullptr, docURI, content->OwnerDoc()->GetReferrerPolicy(),
+                      nullptr, nullptr, mBackgroundFile, loadContext);
 }
 
 NS_IMETHODIMP


### PR DESCRIPTION
When downloading an image as desktop background, the `SaveURI` call seems to have added a `referrerPolicy` argument.  Is `0` the right value for it, or what should it be?

> 35:19.47 /Users/pale/jenkins/workspace/tycho/default/browser/components/shell/nsMacShellService.cpp:206:51: error: too few arguments to function call, expected 8, have 7
35:19.47                       mBackgroundFile, loadContext);
35:19.48                                                   ^
35:19.48 ../../../dist/include/nsIWebBrowserPersist.h:86:3: note: 'SaveURI' declared here
35:19.48   NS_IMETHOD SaveURI(nsIURI *aURI, nsISupports *aCacheKey, nsIURI *aReferrer, uint32_t aReferrerPolicy, nsIInputStream *aPostData, const char * aExtraHeaders, nsISupports *aFile, nsILoadContext *aPrivacyContext) = 0;