### PR TITLE
nsMacShellService: PRUnichar to char16_t

### DIFF
--- a/browser/components/shell/nsMacShellService.cpp
+++ b/browser/components/shell/nsMacShellService.cpp
@@ -230,7 +230,7 @@ NS_IMETHODIMP
 nsMacShellService::OnStatusChange(nsIWebProgress* aWebProgress,
                                   nsIRequest* aRequest,
                                   nsresult aStatus,
-                                  const PRUnichar* aMessage)
+                                  const char16_t* aMessage)
 {
   return NS_OK;
 }


### PR DESCRIPTION
>  2:20.08 /Users/pale/jenkins/workspace/tycho/default/browser/components/shell/nsMacShellService.cpp:230:20: error: out-of-line definition of 'OnStatusChange' does not match any declaration in 'nsMacShellService'
 2:20.08 nsMacShellService::OnStatusChange(nsIWebProgress* aWebProgress,