### PR TITLE
Preprocess branding prefs and use preprocessing on UA Overrides

### DIFF
--- a/browser/branding/common/uaoverrides.inc
+++ b/browser/branding/common/uaoverrides.inc
@@ -1,0 +1,53 @@
+#define GUAO_PREF general.useragent.override
+
+#define GRE_VERSION 3.0
+#define GRE_VERSION_SLICE Goanna/@GRE_VERSION@
+#define GRE_DATE_SLICE Goanna/20160101
+#define PM_SLICE PaleMoon/@MOZ_APP_VERSION@
+
+#define GK_VERSION 45.9
+#define GK_SLICE Gecko/20100101
+#define FX_SLICE Firefox/@GK_VERSION@
+
+#ifdef XP_WIN
+#define OS_SLICE Windows NT 6.1; WOW64;
+#elif XP_UNIX
+#ifndef XP_MACOSX
+#define OS_SLICE X11; Linux x86_64;
+#else
+#define OS_SLICE Macintosh; Intel Mac OS X 10.11;
+#endif
+#endif
+
+// Required for domains that have proven unresponsive to requests from users
+pref("@GUAO_PREF@.live.com","Mozilla/5.0 (@OS_SLICE@ rv:@GK_VERSION@) @GK_SLICE@ @FX_SLICE@ (Pale Moon)");
+pref("@GUAO_PREF@.outlook.com","Mozilla/5.0 (@OS_SLICE@ rv:@GK_VERSION@) @GK_SLICE@ @FX_SLICE@ (Pale Moon)");
+pref("@GUAO_PREF@.web.de","Mozilla/5.0 (@OS_SLICE@ rv:@GK_VERSION@) @GK_SLICE@ @FX_SLICE@ (Pale Moon)");
+pref("@GUAO_PREF@.aol.com","Mozilla/5.0 (@OS_SLICE@ rv:@GK_VERSION@) @GK_SLICE@ @FX_SLICE@ (Pale Moon)");
+pref("@GUAO_PREF@.calendar.yahoo.com","Mozilla/5.0 (@OS_SLICE@ rv:@GK_VERSION@) @GK_SLICE@ @FX_SLICE@ (Pale Moon)");
+pref("@GUAO_PREF@.google.com","Mozilla/5.0 (@OS_SLICE@ rv:@GK_VERSION@) @GK_SLICE@ @GRE_VERSION_SLICE@ @FX_SLICE@ @PM_SLICE@");
+pref("@GUAO_PREF@.googlevideos.com","Mozilla/5.0 (@OS_SLICE@ rv:38.9) @GK_SLICE@ @GRE_VERSION_SLICE@ Firefox/38.9 @PM_SLICE@");
+pref("@GUAO_PREF@.gstatic.com","Mozilla/5.0 (@OS_SLICE@ rv:31.9) @GK_SLICE@ @GRE_VERSION_SLICE@ Firefox/31.9 @PM_SLICE@");
+pref("@GUAO_PREF@.youtube.com","Mozilla/5.0 (@OS_SLICE@ rv:42.0) @GRE_VERSION_SLICE@ Firefox/42.0 @PM_SLICE@");
+pref("@GUAO_PREF@.netflix.com","Mozilla/5.0 (@OS_SLICE@ rv:38.9) @GK_SLICE@ Firefox/38.9");
+
+// UA-Sniffing domains below are pending responses from their operators - temp workaround
+pref("@GUAO_PREF@.facebook.com","Mozilla/5.0 (@OS_SLICE@ rv:@GK_VERSION@) @GK_SLICE@ @GRE_VERSION_SLICE@ @FX_SLICE@ @PM_SLICE@");
+pref("@GUAO_PREF@.fbcdn.com","Mozilla/5.0 (@OS_SLICE@ rv:@GK_VERSION@) @GK_SLICE@ @GRE_VERSION_SLICE@ @FX_SLICE@ @PM_SLICE@");
+pref("@GUAO_PREF@.chase.com","Mozilla/5.0 (@OS_SLICE@ rv:@GK_VERSION@) @GK_SLICE@ @FX_SLICE@");
+// Citi requires native mode. Or it blocks.. "too old firefox"
+pref("@GUAO_PREF@.citi.com","Mozilla/5.0 (@OS_SLICE@ rv:@GRE_VERSION@) @GRE_DATE_SLICE@ @PM_SLICE@");
+// Yuku fora don't like the Goanna slice (result: broken mobile site)
+pref("@GUAO_PREF@.yuku.com","Mozilla/5.0 (@OS_SLICE@ rv:@GK_VERSION@) @GK_SLICE@ @FX_SLICE@ @PM_SLICE@");
+
+// UA-Sniffing domains below have indicated no interest in supporting Pale Moon (BOO!)
+pref("@GUAO_PREF@.icloud.com","Mozilla/5.0 (@OS_SLICE@ rv:@GK_VERSION@) @GK_SLICE@ @FX_SLICE@ (Pale Moon))");
+pref("@GUAO_PREF@.humblebundle.com","Mozilla/5.0 (@OS_SLICE@ rv:@GK_VERSION@) @GK_SLICE@ @FX_SLICE@ (Pale Moon)");
+pref("@GUAO_PREF@.privat24.ua","Mozilla/5.0 (@OS_SLICE@ rv:38.0) @GK_SLICE@ Firefox/38.0");
+
+// UA-sniffing domains that are "app/vendor-specific" and don't like Pale Moon
+pref("@GUAO_PREF@.web.whatsapp.com","Mozilla/5.0 (Windows NT 6.3; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/37.0.2049.0 Safari/537.36");
+
+// The following domains don't like the Goanna slice
+pref("@GUAO_PREF@.hitbox.tv","Mozilla/5.0 (@OS_SLICE@; rv:@GK_VERSION@) @GK_SLICE@ @FX_SLICE@);
+

--- a/browser/branding/common/uaoverrides.inc
+++ b/browser/branding/common/uaoverrides.inc
@@ -9,14 +9,14 @@
 #define GK_SLICE Gecko/20100101
 #define FX_SLICE Firefox/@GK_VERSION@
 
-#ifdef XP_WIN
-#define OS_SLICE Windows NT 6.1; WOW64;
-#elif XP_UNIX
+#ifdef XP_UNIX
 #ifndef XP_MACOSX
 #define OS_SLICE X11; Linux x86_64;
 #else
 #define OS_SLICE Macintosh; Intel Mac OS X 10.11;
 #endif
+#else
+#define OS_SLICE Windows NT 6.1; WOW64;
 #endif
 
 // Required for domains that have proven unresponsive to requests from users
@@ -28,7 +28,7 @@ pref("@GUAO_PREF@.calendar.yahoo.com","Mozilla/5.0 (@OS_SLICE@ rv:@GK_VERSION@) 
 pref("@GUAO_PREF@.google.com","Mozilla/5.0 (@OS_SLICE@ rv:@GK_VERSION@) @GK_SLICE@ @GRE_VERSION_SLICE@ @FX_SLICE@ @PM_SLICE@");
 pref("@GUAO_PREF@.googlevideos.com","Mozilla/5.0 (@OS_SLICE@ rv:38.9) @GK_SLICE@ @GRE_VERSION_SLICE@ Firefox/38.9 @PM_SLICE@");
 pref("@GUAO_PREF@.gstatic.com","Mozilla/5.0 (@OS_SLICE@ rv:31.9) @GK_SLICE@ @GRE_VERSION_SLICE@ Firefox/31.9 @PM_SLICE@");
-pref("@GUAO_PREF@.youtube.com","Mozilla/5.0 (@OS_SLICE@ rv:42.0) @GRE_VERSION_SLICE@ Firefox/42.0 @PM_SLICE@");
+pref("@GUAO_PREF@.youtube.com","Mozilla/5.0 (@OS_SLICE@ rv:42.0) @GK_SLICE@ @GRE_VERSION_SLICE@ Firefox/42.0 @PM_SLICE@");
 pref("@GUAO_PREF@.netflix.com","Mozilla/5.0 (@OS_SLICE@ rv:38.9) @GK_SLICE@ Firefox/38.9");
 
 // UA-Sniffing domains below are pending responses from their operators - temp workaround
@@ -41,7 +41,7 @@ pref("@GUAO_PREF@.citi.com","Mozilla/5.0 (@OS_SLICE@ rv:@GRE_VERSION@) @GRE_DATE
 pref("@GUAO_PREF@.yuku.com","Mozilla/5.0 (@OS_SLICE@ rv:@GK_VERSION@) @GK_SLICE@ @FX_SLICE@ @PM_SLICE@");
 
 // UA-Sniffing domains below have indicated no interest in supporting Pale Moon (BOO!)
-pref("@GUAO_PREF@.icloud.com","Mozilla/5.0 (@OS_SLICE@ rv:@GK_VERSION@) @GK_SLICE@ @FX_SLICE@ (Pale Moon))");
+pref("@GUAO_PREF@.icloud.com","Mozilla/5.0 (@OS_SLICE@ rv:@GK_VERSION@) @GK_SLICE@ @FX_SLICE@ (Pale Moon)");
 pref("@GUAO_PREF@.humblebundle.com","Mozilla/5.0 (@OS_SLICE@ rv:@GK_VERSION@) @GK_SLICE@ @FX_SLICE@ (Pale Moon)");
 pref("@GUAO_PREF@.privat24.ua","Mozilla/5.0 (@OS_SLICE@ rv:38.0) @GK_SLICE@ Firefox/38.0");
 
@@ -49,5 +49,5 @@ pref("@GUAO_PREF@.privat24.ua","Mozilla/5.0 (@OS_SLICE@ rv:38.0) @GK_SLICE@ Fire
 pref("@GUAO_PREF@.web.whatsapp.com","Mozilla/5.0 (Windows NT 6.3; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/37.0.2049.0 Safari/537.36");
 
 // The following domains don't like the Goanna slice
-pref("@GUAO_PREF@.hitbox.tv","Mozilla/5.0 (@OS_SLICE@; rv:@GK_VERSION@) @GK_SLICE@ @FX_SLICE@);
+pref("@GUAO_PREF@.hitbox.tv","Mozilla/5.0 (@OS_SLICE@; rv:@GK_VERSION@) @GK_SLICE@ @FX_SLICE@");
 

--- a/browser/branding/official/moz.build
+++ b/browser/branding/official/moz.build
@@ -12,3 +12,5 @@ export('DIST_SUBDIR')
 JS_PREFERENCE_FILES += [
     'pref/firefox-branding.js',
 ]
+
+DEFINES['MOZ_APP_VERSION'] = CONFIG['MOZ_APP_VERSION']

--- a/browser/branding/official/pref/firefox-branding.js
+++ b/browser/branding/official/pref/firefox-branding.js
@@ -1,3 +1,5 @@
+#filter substitution
+
 // ****************** App/Update/General ******************
 
 pref("startup.homepage_override_url","http://www.palemoon.org/releasenotes.shtml");
@@ -60,38 +62,7 @@ pref("extensions.blocklist.url","http://blocklist.palemoon.org/%VERSION%/blockli
 pref("extensions.blocklist.itemURL", "http://blocklist.palemoon.org/info/?id=%blockID%");
 
 // ****************** domain-specific UAs ******************
-
-// Required for domains that have proven unresponsive to requests from users
-pref("general.useragent.override.live.com","Mozilla/5.0 (Windows NT 6.1; WOW64; rv:45.9) Gecko/20100101 Firefox/45.9 (Pale Moon)");
-pref("general.useragent.override.outlook.com","Mozilla/5.0 (Windows NT 6.1; WOW64; rv:45.9) Gecko/20100101 Firefox/45.9 (Pale Moon)");
-pref("general.useragent.override.web.de","Mozilla/5.0 (Windows NT 6.1; WOW64; rv:45.9) Gecko/20100101 Firefox/45.9 (Pale Moon)");
-pref("general.useragent.override.aol.com","Mozilla/5.0 (Windows NT 6.1; WOW64; rv:45.9) Gecko/20100101 Firefox/45.9 (Pale Moon)");
-pref("general.useragent.override.google.com","Mozilla/5.0 (Windows NT 6.1; WOW64; rv:45.9) Gecko/20100101 Goanna/3.0 Firefox/45.9 PaleMoon/27.0");
-pref("general.useragent.override.googlevideos.com","Mozilla/5.0 (Windows NT 6.1; WOW64; rv:38.9) Gecko/20100101 Goanna/3.0 Firefox/38.9 PaleMoon/27.0");
-pref("general.useragent.override.gstatic.com","Mozilla/5.0 (Windows NT 6.1; WOW64; rv:31.9) Gecko/20100101 Goanna/3.0 Firefox/31.9 PaleMoon/27.0");
-pref("general.useragent.override.youtube.com","Mozilla/5.0 (Windows NT 6.1; rv:42.0) Gecko/20100101 Firefox/42.0 PaleMoon/27.0");
-pref("general.useragent.override.netflix.com","Mozilla/5.0 (Windows NT 6.1; WOW64; rv:38.9) Gecko/20100101 Firefox/38.9");
-pref("general.useragent.override.calendar.yahoo.com","Mozilla/5.0 (Windows NT 6.1; WOW64; rv:45.9) Gecko/20100101 Firefox/45.9 (Pale Moon)");
-
-// UA-Sniffing domains below are pending responses from their operators - temp workaround
-pref("general.useragent.override.facebook.com","Mozilla/5.0 (Windows NT 6.1; WOW64; rv:45.9) Gecko/20100101 Goanna/3.0 Firefox/45.9 PaleMoon/27.0");
-pref("general.useragent.override.fbcdn.com","Mozilla/5.0 (Windows NT 6.1; WOW64; rv:45.9) Gecko/20100101 Goanna/3.0 Firefox/45.9 PaleMoon/27.0");
-pref("general.useragent.override.chase.com","Mozilla/5.0 (Windows NT 6.1; WOW64; rv:45.9) Gecko/20100101 Firefox/45.9");
-// Citi requires native mode. Or it blocks.. "too old firefox"
-pref("general.useragent.override.citi.com","Mozilla/5.0 (Windows NT 6.1; WOW64; rv:2.0) Goanna/20160101 PaleMoon/27.0");
-// Yuku fora don't like the Goanna slice (result: broken mobile site)
-pref("general.useragent.override.yuku.com","Mozilla/5.0 (Windows NT 6.1; WOW64; rv:45.9) Gecko/20100101 Firefox/45.9 PaleMoon/27.0");
-
-// UA-Sniffing domains below have indicated no interest in supporting Pale Moon (BOO!)
-pref("general.useragent.override.humblebundle.com","Mozilla/5.0 (Windows NT 6.1; WOW64; rv:45.0) Gecko/20100101 Firefox/45.0 (Pale Moon)");
-pref("general.useragent.override.privat24.ua","Mozilla/5.0 (Windows NT 6.1; WOW64; rv:38.0) Gecko/20100101 Firefox/38.0");
-pref("general.useragent.override.icloud.com","Mozilla/5.0 (Windows NT 6.1; WOW64; rv:45.0) Gecko/20100101 Firefox/45.0 (Pale Moon)");
-
-// UA-sniffing domains that are "app/vendor-specific" and don't like Pale Moon
-pref("general.useragent.override.web.whatsapp.com","Mozilla/5.0 (Windows NT 6.3; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/37.0.2049.0 Safari/537.36");
-
-// The following domains don't like the Goanna slice
-pref("general.useragent.override.hitbox.tv","Mozilla/5.0 (Windows NT 6.1; WOW64; rv:45.9) Gecko/20100101 Firefox/45.9");
+#include ../../common/uaoverrides.inc
 
 // Enable Firefox compatibility mode globally?
 pref("general.useragent.compatMode.firefox", true);

--- a/browser/branding/unofficial/moz.build
+++ b/browser/branding/unofficial/moz.build
@@ -12,3 +12,5 @@ export('DIST_SUBDIR')
 JS_PREFERENCE_FILES += [
     'pref/firefox-branding.js',
 ]
+
+DEFINES['MOZ_APP_VERSION'] = CONFIG['MOZ_APP_VERSION']

--- a/browser/branding/unofficial/pref/firefox-branding.js
+++ b/browser/branding/unofficial/pref/firefox-branding.js
@@ -1,3 +1,5 @@
+#filter substitution
+
 // ****************** App/Update/General ******************
 
 pref("startup.homepage_override_url","http://www.palemoon.org/releasenotes.shtml");
@@ -59,38 +61,7 @@ pref("extensions.blocklist.url","http://blocklist.palemoon.org/%VERSION%/blockli
 pref("extensions.blocklist.itemURL", "http://blocklist.palemoon.org/info/?id=%blockID%");
 
 // ****************** domain-specific UAs ******************
-
-// Required for domains that have proven unresponsive to requests from users
-pref("general.useragent.override.live.com","Mozilla/5.0 (Windows NT 6.1; WOW64; rv:45.9) Gecko/20100101 Firefox/45.9 (Pale Moon)");
-pref("general.useragent.override.outlook.com","Mozilla/5.0 (Windows NT 6.1; WOW64; rv:45.9) Gecko/20100101 Firefox/45.9 (Pale Moon)");
-pref("general.useragent.override.web.de","Mozilla/5.0 (Windows NT 6.1; WOW64; rv:45.9) Gecko/20100101 Firefox/45.9 (Pale Moon)");
-pref("general.useragent.override.aol.com","Mozilla/5.0 (Windows NT 6.1; WOW64; rv:45.9) Gecko/20100101 Firefox/45.9 (Pale Moon)");
-pref("general.useragent.override.google.com","Mozilla/5.0 (Windows NT 6.1; WOW64; rv:45.9) Gecko/20100101 Goanna/3.0 Firefox/45.9 PaleMoon/27.0");
-pref("general.useragent.override.googlevideos.com","Mozilla/5.0 (Windows NT 6.1; WOW64; rv:38.9) Gecko/20100101 Goanna/3.0 Firefox/38.9 PaleMoon/27.0");
-pref("general.useragent.override.gstatic.com","Mozilla/5.0 (Windows NT 6.1; WOW64; rv:31.9) Gecko/20100101 Goanna/3.0 Firefox/31.9 PaleMoon/27.0");
-pref("general.useragent.override.youtube.com","Mozilla/5.0 (Windows NT 6.1; rv:42.0) Gecko/20100101 Firefox/42.0 PaleMoon/27.0");
-pref("general.useragent.override.netflix.com","Mozilla/5.0 (Windows NT 6.1; WOW64; rv:38.9) Gecko/20100101 Firefox/38.9");
-pref("general.useragent.override.calendar.yahoo.com","Mozilla/5.0 (Windows NT 6.1; WOW64; rv:45.9) Gecko/20100101 Firefox/45.9 (Pale Moon)");
-
-// UA-Sniffing domains below are pending responses from their operators - temp workaround
-pref("general.useragent.override.facebook.com","Mozilla/5.0 (Windows NT 6.1; WOW64; rv:45.9) Gecko/20100101 Goanna/3.0 Firefox/45.9 PaleMoon/27.0");
-pref("general.useragent.override.fbcdn.com","Mozilla/5.0 (Windows NT 6.1; WOW64; rv:45.9) Gecko/20100101 Goanna/3.0 Firefox/45.9 PaleMoon/27.0");
-pref("general.useragent.override.chase.com","Mozilla/5.0 (Windows NT 6.1; WOW64; rv:45.9) Gecko/20100101 Firefox/45.9");
-// Citi requires native mode. Or it blocks.. "too old firefox"
-pref("general.useragent.override.citi.com","Mozilla/5.0 (Windows NT 6.1; WOW64; rv:2.0) Goanna/20160101 PaleMoon/27.0");
-// Yuku fora don't like the Goanna slice (result: broken mobile site)
-pref("general.useragent.override.yuku.com","Mozilla/5.0 (Windows NT 6.1; WOW64; rv:45.9) Gecko/20100101 Firefox/45.9 PaleMoon/27.0");
-
-// UA-Sniffing domains below have indicated no interest in supporting Pale Moon (BOO!)
-pref("general.useragent.override.humblebundle.com","Mozilla/5.0 (Windows NT 6.1; WOW64; rv:45.0) Gecko/20100101 Firefox/45.0 (Pale Moon)");
-pref("general.useragent.override.privat24.ua","Mozilla/5.0 (Windows NT 6.1; WOW64; rv:38.0) Gecko/20100101 Firefox/38.0");
-pref("general.useragent.override.icloud.com","Mozilla/5.0 (Windows NT 6.1; WOW64; rv:45.0) Gecko/20100101 Firefox/45.0 (Pale Moon)");
-
-// UA-sniffing domains that are "app/vendor-specific" and don't like Pale Moon
-pref("general.useragent.override.web.whatsapp.com","Mozilla/5.0 (Windows NT 6.3; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/37.0.2049.0 Safari/537.36");
-
-// The following domains don't like the Goanna slice
-pref("general.useragent.override.hitbox.tv","Mozilla/5.0 (Windows NT 6.1; WOW64; rv:45.9) Gecko/20100101 Firefox/45.9");
+#include ../../common/uaoverrides.inc
 
 // Enable Firefox compatibility mode globally?
 pref("general.useragent.compatMode.firefox", false);


### PR DESCRIPTION
This allows us to reduce the amount of duplication and work for Site Specific User Agent Overrides.

We activate the preprocessor on branding prefs and then since the UAOs are present in both sets of branding we localize it to it's own file and merely include it in browser/branding/*/pref/firefox-branding.js

The UAOs are constructed using the filter substituted variable defines at the top of  browser/branding/common/uaoverrides.inc

They are:

**GUAO_PREF** which is merely general.useragent.override

**GRE_VERSION** This should be kept in sync with the Milestone version
**GRE_VERSION_SLICE** This has the Goanna slice with the version number
**GRE_DATE_SLICE** this has the Goanna slice with a fixed date
**PM_SLICE** this has the Pale Moon slice with the current MOZ_APP_VERSION that is set in browser/config/version.txt

**GK_VERSION** this is the shared Gecko/Firefox ESR Version we are telling websites
**GK_SLICE** this has the Gecko slice with Mozilla's static date
**FX_SLICE** this is the Firefox slice using the shared Gecko/Firefox ESR Version

**OS_SLICE** is determined by the target platform so that UAOs actually state what OS they are on. For OSX it is the most recent version and for Windows we assume Windows 7 32bit (NT 6.1)

Of course there are exceptions so you can specify those pieces directly instead of using the preprocessed variables.

Also, filter substitution by default will replace @DEFINE@ with it's value.