### PR TITLE
Add missing MacOS-files.in

### DIFF
--- a/browser/app/macbuild/Contents/MacOS-files.in
+++ b/browser/app/macbuild/Contents/MacOS-files.in
@@ -1,0 +1,10 @@
+/*.app/***
+/*.dylib
+/certutil
+/firefox-bin
+/gtest/***
+/pk12util
+/ssltunnel
+/xpcshell
+/XUL
+


### PR DESCRIPTION
cribbed from http://xref.palemoon.org/mozilla-esr38/source/browser/app/macbuild/Contents/MacOS-files.in?raw=1

>  3:38.17 Packaging quitter@mozilla.org.xpi...
 3:38.56 rsync: failed to open exclude file /Users/pale/jenkins/workspace/tycho/default/browser/app/macbuild/Contents/MacOS-files.in: No such file or directory (2)
 3:38.56 rsync error: error in file IO (code 11) at /SourceCache/rsync/rsync-42/rsync/exclude.c(1005) [client=2.6.9]

ref #23 #43 