### PR TITLE
Fix GetPluginFile invocation for Mac build

### DIFF
--- a/dom/media/gmp/GMPChild.cpp
+++ b/dom/media/gmp/GMPChild.cpp
@@ -386,8 +386,8 @@ GMPChild::GetLibPath(nsACString& aOutLibPath)
   aOutLibPath.Assign(pluginFilePath);
   return true;
 #else
-  nsCOMPtr<nsIFile> libFile;
-  if (!GetPluginFile(mPluginPath, libFile)) {
+  nsCOMPtr<nsIFile> pluginDirectoryPath, libFile;
+  if (!GetPluginFile(mPluginPath, pluginDirectoryPath, libFile)) {
     return false;
   }
   return NS_SUCCEEDED(libFile->GetNativePath(aOutLibPath));


### PR DESCRIPTION
Open question:  the #ifdef conditions protecting this
function are different at declaration and use sites.
This seems like a natural way to introduce build errors.

Should we expand it to cover all cases?  Or simplify it otherwise?