### PR TITLE
Align NetworkPrioritizer.jsm to Bug 666804's changes

### DIFF
--- a/browser/modules/NetworkPrioritizer.jsm
+++ b/browser/modules/NetworkPrioritizer.jsm
@@ -80,18 +80,12 @@ let BrowserHelper = {
     windowEntry.lastSelectedBrowser = aBrowser;
   },
 
-  // Auxiliary methods
-  getLoadgroup: function NP_BH_getLoadgroup(aBrowser) {
-    return aBrowser.webNavigation.QueryInterface(Ci.nsIDocumentLoader)
-                   .loadGroup.QueryInterface(Ci.nsISupportsPriority);
-  },
-
   increasePriority: function NP_BH_increasePriority(aBrowser) {
-    this.getLoadgroup(aBrowser).adjustPriority(PRIORITY_DELTA);
+    aBrowser.adjustPriority(PRIORITY_DELTA);
   },
 
   decreasePriority: function NP_BH_decreasePriority(aBrowser) {
-    this.getLoadgroup(aBrowser).adjustPriority(PRIORITY_DELTA * -1);
+    aBrowser.adjustPriority(PRIORITY_DELTA * -1);
   }
 };
 


### PR DESCRIPTION
This fixes the intermittent error which became an always occurring error around the time jetpack's files were moved from commonjs. (Somehow this was related to the SDK but not directly, the e10s bug resolved it)

```
Timestamp: 7/8/2016 2:41:47 PM
Error: TypeError: aBrowser.webNavigation is undefined
Source File: resource://app/modules/NetworkPrioritizer.jsm
Line: 85
```

Bug 666804 was an e10s bug but it's changes to toolkit browser bindings may have been conflicting. This PR aligns NetworkPrioritizer.jsm to match toolkit.