### PR TITLE
Change default MOZ_OPTIMIZE_FLAGS for GCC to -O2

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -2093,7 +2093,7 @@ ia64*-hpux*)
     TARGET_NSPR_MDCPUCFG='\"md/_linux.cfg\"'
 
     MOZ_GFX_OPTIMIZE_MOBILE=1
-    MOZ_OPTIMIZE_FLAGS="-Os -fno-reorder-functions"
+    MOZ_OPTIMIZE_FLAGS="-O2 -fno-reorder-functions"
     if test -z "$CLANG_CC"; then
        MOZ_OPTIMIZE_FLAGS="-freorder-blocks $MOZ_OPTIMIZE_FLAGS"
     fi
@@ -2108,7 +2108,7 @@ ia64*-hpux*)
         MOZ_OPTIMIZE_FLAGS="-O2"
     elif test "$GNU_CC" -o "$GNU_CXX"; then
         MOZ_PGO_OPTIMIZE_FLAGS="-O3"
-        MOZ_OPTIMIZE_FLAGS="-Os"
+        MOZ_OPTIMIZE_FLAGS="-O2"
         if test -z "$CLANG_CC"; then
            MOZ_OPTIMIZE_FLAGS="-freorder-blocks $MOZ_OPTIMIZE_FLAGS"
         fi


### PR DESCRIPTION
https://forum.palemoon.org/viewtopic.php?f=37&p=88000

Using -O2 results in a tarball that is exactly 2.9MB larger than when using -Os, so the smaller size does not outweigh the potential performance advantages of using -O2.