### PR TITLE
Enable Tycho to be built with GCC 6.x

### DIFF
--- a/config/gcc-stl-wrapper.template.h
+++ b/config/gcc-stl-wrapper.template.h
@@ -22,6 +22,11 @@
 #define NOMINMAX 1
 #endif
 
+// Don't include mozalloc for cstdlib. See bug 1245076.
+#ifndef moz_dont_include_mozalloc_for_cstdlib
+#  define moz_dont_include_mozalloc_for_cstdlib
+#endif
+#ifndef moz_dont_include_mozalloc_for_${HEADER}
 // mozalloc.h wants <new>; break the cycle by always explicitly
 // including <new> here.  NB: this is a tad sneaky.  Sez the gcc docs:
 //
@@ -30,15 +35,17 @@
 //    same name as the current file. It simply looks for the file
 //    named, starting with the directory in the search path after the
 //    one where the current file was found.
-#include_next <new>
+#  include_next <new>
 
 // See if we're in code that can use mozalloc.  NB: this duplicates
 // code in nscore.h because nscore.h pulls in prtypes.h, and chromium
 // can't build with that being included before base/basictypes.h.
-#if !defined(XPCOM_GLUE) && !defined(NS_NO_XPCOM) && !defined(MOZ_NO_MOZALLOC)
-#  include "mozilla/mozalloc.h"
-#else
-#  error "STL code can only be used with infallible ::operator new()"
+#  if !defined(XPCOM_GLUE) && !defined(NS_NO_XPCOM) && !defined(MOZ_NO_MOZALLOC)
+#    include "mozilla/mozalloc.h"
+#  else
+#    error "STL code can only be used with infallible ::operator new()"
+#  endif
+
 #endif
 
 #if defined(DEBUG) && !defined(_GLIBCXX_DEBUG)

--- a/configure.in
+++ b/configure.in
@@ -1659,6 +1659,12 @@ else
     _DEFINES_CXXFLAGS='-DMOZILLA_CLIENT -D_MOZILLA_CONFIG_H_ $(ACDEFINES)'
 fi
 
+#FIXME: Work around breaking optimizations performed by GCC 6
+if test "$GCC_MAJOR_VERSION" -eq "6" ; then
+    CFLAGS="$CFLAGS -fno-delete-null-pointer-checks -fno-lifetime-dse -fno-schedule-insns2"
+    CXXFLAGS="$CXXFLAGS -fno-delete-null-pointer-checks -fno-lifetime-dse -fno-schedule-insns2"
+fi
+
 dnl gcc can come with its own linker so it is better to use the pass-thru calls
 dnl MKSHLIB_FORCE_ALL is used to force the linker to include all object
 dnl files present in an archive. MKSHLIB_UNFORCE_ALL reverts the linker to

--- a/gfx/graphite2/src/Collider.cpp
+++ b/gfx/graphite2/src/Collider.cpp
@@ -26,7 +26,7 @@ of the License or (at your option) any later version.
 */
 #include <algorithm>
 #include <limits>
-#include <math.h>
+#include <cmath>
 #include <string>
 #include <functional>
 #include "inc/Collider.h"

--- a/gfx/graphite2/src/Collider.cpp
+++ b/gfx/graphite2/src/Collider.cpp
@@ -26,7 +26,7 @@ of the License or (at your option) any later version.
 */
 #include <algorithm>
 #include <limits>
-#include <cmath>
+#include <math.h>
 #include <string>
 #include <functional>
 #include "inc/Collider.h"


### PR DESCRIPTION
And for Tycho. Exactly the same changes as [Pale Moon PR #463](https://github.com/MoonchildProductions/Pale-Moon/pull/463)

I can confirm it works as intended and does not break GCC 5.3 builds.