### PR TITLE
Include cmath instead of math.h in Collider.cpp (GCC 6 only)

### DIFF
--- a/gfx/graphite2/src/Collider.cpp
+++ b/gfx/graphite2/src/Collider.cpp
@@ -26,7 +26,11 @@ of the License or (at your option) any later version.
 */
 #include <algorithm>
 #include <limits>
+#if defined(__GNUC__) && (__GNUC__ >= 6)
+#include <cmath>
+#else
 #include <math.h>
+#endif
 #include <string>
 #include <functional>
 #include "inc/Collider.h"


### PR DESCRIPTION
This should be the last fix needed to get a working browser when built with GCC 6.x.

Note that unlike Pale Moon v26, Link Time Optimization is **not** required to get a successful build.