### PR TITLE
Always invalidate nsAppRunner so that we get an always up to date build id for nsIXULAppInfo.platformBuildID on incremental builds

### DIFF
--- a/toolkit/xre/Makefile.in
+++ b/toolkit/xre/Makefile.in
@@ -40,7 +40,7 @@ $(call errorIfEmpty,GRE_MILESTONE GRE_BUILDID)
 
 DEFINES += -DGRE_BUILDID=$(GRE_BUILDID)
 
-.PHONY: nsAppRunner.obj
+.PHONY: nsAppRunner.$(OBJ_SUFFIX)
 
 $(srcdir)/nsAppRunner.cpp: $(DEPTH)/config/buildid $(milestone_txt)
 

--- a/toolkit/xre/Makefile.in
+++ b/toolkit/xre/Makefile.in
@@ -40,6 +40,8 @@ $(call errorIfEmpty,GRE_MILESTONE GRE_BUILDID)
 
 DEFINES += -DGRE_BUILDID=$(GRE_BUILDID)
 
+.PHONY: nsAppRunner.obj
+
 $(srcdir)/nsAppRunner.cpp: $(DEPTH)/config/buildid $(milestone_txt)
 
 platform.ini: FORCE


### PR DESCRIPTION
On incremental builds the buildid for the platform was not being updated. This will cause nsAppRunner to be considered always out of date and be always rebuilt refreshing GRE_BUILDID as stored in nsIXULAppInfo.platformBuildID.

This comes at a minor cost of having to relink libxul but only adds a very small amount of time to incremental builds. (around 30 seconds to a minute)