### PR TITLE
Tycho pick of FreeBSD bug 206545 -- build broken on clang >= 3.8.0

### DIFF
--- a/dom/events/MessageEvent.h
+++ b/dom/events/MessageEvent.h
@@ -15,9 +15,6 @@ namespace mozilla {
 namespace dom {
 
 struct MessageEventInit;
-class MessagePort;
-class MessagePortBase;
-class MessagePortList;
 class OwningWindowProxyOrMessagePort;
 
 /**


### PR DESCRIPTION
http://lists.freebsd.org/pipermail/freebsd-gecko/2016-January/006009.html
https://github.com/jsonn/pkgsrc/blob/trunk/www/firefox38/patches/patch-dom_events_MessageEvent.h