### PR TITLE
Disallow Jetpack/SDK extensions to be installed and used

### DIFF
--- a/browser/base/content/browser-addons.js
+++ b/browser/base/content/browser-addons.js
@@ -165,6 +165,8 @@ const gXPInstallObserver = {
         let error = (host || install.error == 0) ? "addonError" : "addonLocalError";
         if (install.error != 0)
           error += install.error;
+        else if (install.addon.jetsdk)
+          error += "JetSDK";
         else if (install.addon.blocklistState == Ci.nsIBlocklistService.STATE_BLOCKED)
           error += "Blocklisted";
         else

--- a/browser/locales/en-US/chrome/browser/browser.properties
+++ b/browser/locales/en-US/chrome/browser/browser.properties
@@ -67,6 +67,7 @@ addonLocalError-3=This add-on could not be installed because it appears to be co
 addonLocalError-4=#1 could not be installed because #3 cannot modify the needed file.
 addonErrorIncompatible=#1 could not be installed because it is not compatible with #3 #4.
 addonErrorBlocklisted=#1 could not be installed because it has a high risk of causing stability or security problems.
+addonErrorJetSDK=#1 could not be installed because it is a Jetpack/SDK extension which are not supported in #3 #4.
 
 # LOCALIZATION NOTE (lwthemeInstallRequest.message): %S will be replaced with
 # the host name of the site.

--- a/toolkit/mozapps/extensions/internal/XPIProvider.jsm
+++ b/toolkit/mozapps/extensions/internal/XPIProvider.jsm
@@ -1090,10 +1090,10 @@ function loadManifestFromZipReader(aZipReader) {
       addon.hasBinaryComponents = false;
     }
 
-    // Append a property with boolean value whether the .xpi
-    // archive contains files related to Jetpack and Add-on SDK
-    addon["jetsdk"] = aZipReader.hasEntry("package.json")
-                   || aZipReader.hasEntry("harness-options.json");
+    // Set a boolean value whether the .xpi archive
+    // contains files related to Jetpack and Add-on SDK
+    addon.jetsdk = aZipReader.hasEntry("package.json")
+                || aZipReader.hasEntry("harness-options.json");
     
     addon.appDisabled = !isUsableAddon(addon);
     return addon;
@@ -6655,7 +6655,7 @@ function AddonWrapper(aAddon) {
    "providesUpdatesSecurely", "blocklistState", "blocklistURL", "appDisabled",
    "softDisabled", "skinnable", "size", "foreignInstall", "hasBinaryComponents",
    "strictCompatibility", "compatibilityOverrides", "updateURL",
-   "getDataDirectory", "multiprocessCompatible"].forEach(function(aProp) {
+   "getDataDirectory", "multiprocessCompatible", "jetsdk"].forEach(function(aProp) {
      this.__defineGetter__(aProp, function AddonWrapper_propertyGetter() aAddon[aProp]);
   }, this);
 

--- a/toolkit/mozapps/extensions/internal/XPIProvider.jsm
+++ b/toolkit/mozapps/extensions/internal/XPIProvider.jsm
@@ -634,6 +634,9 @@ function isUsableAddon(aAddon) {
   if (aAddon.type == "theme" && aAddon.internalName == XPIProvider.defaultSkin)
     return true;
 
+  if (aAddon.jetsdk)
+    return false;
+
   if (aAddon.blocklistState == Blocklist.STATE_BLOCKED)
     return false;
 
@@ -1087,6 +1090,11 @@ function loadManifestFromZipReader(aZipReader) {
       addon.hasBinaryComponents = false;
     }
 
+    // Append a property with boolean value whether the .xpi
+    // archive contains files related to Jetpack and Add-on SDK
+    addon["jetsdk"] = aZipReader.hasEntry("package.json")
+                   || aZipReader.hasEntry("harness-options.json");
+    
     addon.appDisabled = !isUsableAddon(addon);
     return addon;
   }


### PR DESCRIPTION
Assuming that extensions of this kind are no longer supported and they will not work at all anymore.