### PR TITLE
Disallow also already installed Jetpack/SDK extensions to be used

### DIFF
--- a/toolkit/locales/en-US/chrome/mozapps/extensions/extensions.properties
+++ b/toolkit/locales/en-US/chrome/mozapps/extensions/extensions.properties
@@ -23,6 +23,7 @@ dateUpdated=Updated %S
 
 #LOCALIZATION NOTE (notification.incompatible) %1$S is the add-on name, %2$S is brand name, %3$S is application version
 notification.incompatible=%1$S is incompatible with %2$S %3$S.
+notification.jetsdk=This is a Jetpack/SDK extension which are not supported in %1$S %2$S.
 #LOCALIZATION NOTE (notification.blocked) %1$S is the add-on name
 notification.blocked=%1$S has been disabled due to security or stability issues.
 notification.blocked.link=More Information

--- a/toolkit/mozapps/extensions/content/extensions.xml
+++ b/toolkit/mozapps/extensions/content/extensions.xml
@@ -1247,6 +1247,14 @@
               this._errorLink.value = gStrings.ext.GetStringFromName("notification.blocked.link");
               this._errorLink.href = this.mAddon.blocklistURL;
               this._errorLink.hidden = false;
+            } else if (this.mAddon.jetsdk) {
+              this.setAttribute("notification", "warning");
+              this._warning.textContent = gStrings.ext.formatStringFromName(
+                "notification.jetsdk",
+                [gStrings.brandShortName, gStrings.appVersion], 2
+              );
+              this._warningLink.hidden = true;
+              this._warningBtn.hidden = true;
             } else if ((!isUpgrade && !this.mAddon.isCompatible) && (AddonManager.checkCompatibility
             || (this.mAddon.blocklistState != Ci.nsIBlocklistService.STATE_SOFTBLOCKED))) {
               this.setAttribute("notification", "warning");

--- a/toolkit/mozapps/extensions/internal/XPIProvider.jsm
+++ b/toolkit/mozapps/extensions/internal/XPIProvider.jsm
@@ -3435,6 +3435,9 @@ this.XPIProvider = {
                         changed;
             }
             else {
+              changed = updateMetadata(installLocation, aOldAddon, xpiState) ||
+                        changed;
+              
               changed = updateVisibilityAndCompatibility(installLocation,
                                                          aOldAddon, xpiState) ||
                         changed;

--- a/toolkit/mozapps/extensions/internal/XPIProviderUtils.js
+++ b/toolkit/mozapps/extensions/internal/XPIProviderUtils.js
@@ -70,7 +70,7 @@ const PROP_JSON_FIELDS = ["id", "syncGUID", "location", "version", "type",
                           "skinnable", "size", "sourceURI", "releaseNotesURI",
                           "softDisabled", "foreignInstall", "hasBinaryComponents",
                           "strictCompatibility", "locales", "targetApplications",
-                          "targetPlatforms", "multiprocessCompatible"];
+                          "targetPlatforms", "multiprocessCompatible", "jetsdk"];
 
 // Time to wait before async save of XPI JSON database, in milliseconds
 const ASYNC_SAVE_DELAY_MS = 20;


### PR DESCRIPTION
These changes result in disabling Jetpack/SDK extensions after the browser restart preceded by compatibility check run after an update. Additionally in Add-on Manager's list for each such disabled extension a proper warning is shown. According to previous discussion there is no collision with _strictCompatibility_ checker as I've managed to make this work together. It should be complete now I think.