### PR TITLE
Use nsRefPtr when not defering release of WrappedJS

### DIFF
--- a/js/xpconnect/src/XPCMaps.cpp
+++ b/js/xpconnect/src/XPCMaps.cpp
@@ -90,7 +90,7 @@ JSObject2WrappedJSMap::UpdateWeakPointersAfterGC(XPCJSRuntime* runtime)
     // Check all wrappers and update their JSObject pointer if it has been
     // moved. Release any wrappers whose weakly held JSObject has died.
 
-    nsTArray<RefPtr<nsXPCWrappedJS>> dying;
+    nsTArray<nsRefPtr<nsXPCWrappedJS>> dying;
 
     for (Map::Enum e(mTable); !e.empty(); e.popFront()) {
         nsXPCWrappedJS* wrapper = e.front().value();


### PR DESCRIPTION
Followup to commit 89d161c

Fixes Linux build bustage.