### PR TITLE
Add a simple mechanism for content pages to communicate with chrome

### DIFF
--- a/toolkit/components/processsingleton/MainProcessSingleton.js
+++ b/toolkit/components/processsingleton/MainProcessSingleton.js
@@ -9,14 +9,6 @@ const { utils: Cu, interfaces: Ci, classes: Cc, results: Cr } = Components;
 Cu.import("resource://gre/modules/Services.jsm");
 Cu.import("resource://gre/modules/XPCOMUtils.jsm");
 
-XPCOMUtils.defineLazyServiceGetter(this, "ppmm",
-                                   "@mozilla.org/parentprocessmessagemanager;1",
-                                   "nsIMessageListenerManager");
-
-XPCOMUtils.defineLazyServiceGetter(this, "globalmm",
-                                   "@mozilla.org/globalmessagemanager;1",
-                                   "nsIMessageBroadcaster");
-
 XPCOMUtils.defineLazyModuleGetter(this, "NetUtil",
                                   "resource://gre/modules/NetUtil.jsm");
 
@@ -85,15 +77,15 @@ MainProcessSingleton.prototype = {
 
       // Load this script early so that console.* is initialized
       // before other frame scripts.
-      globalmm.loadFrameScript("chrome://global/content/browser-content.js", true);
-      ppmm.addMessageListener("Console:Log", this.logConsoleMessage);
-      globalmm.addMessageListener("Search:AddEngine", this.addSearchEngine);
+      Services.mm.loadFrameScript("chrome://global/content/browser-content.js", true);
+      Services.ppmm.addMessageListener("Console:Log", this.logConsoleMessage);
+      Services.mm.addMessageListener("Search:AddEngine", this.addSearchEngine);
       break;
     }
 
     case "xpcom-shutdown":
-      ppmm.removeMessageListener("Console:Log", this.logConsoleMessage);
-      globalmm.removeMessageListener("Search:AddEngine", this.addSearchEngine);
+      Services.ppmm.removeMessageListener("Console:Log", this.logConsoleMessage);
+      Services.mm.removeMessageListener("Search:AddEngine", this.addSearchEngine);
       break;
     }
   },

--- a/toolkit/content/browser-content.js
+++ b/toolkit/content/browser-content.js
@@ -23,9 +23,7 @@ let ClickEventHandler = {
     this._screenY = null;
     this._lastFrame = null;
 
-    Cc["@mozilla.org/eventlistenerservice;1"]
-      .getService(Ci.nsIEventListenerService)
-      .addSystemEventListener(global, "mousedown", this, true);
+    Services.els.addSystemEventListener(global, "mousedown", this, true);
 
     addMessageListener("Autoscroll:Stop", this);
   },
@@ -127,9 +125,7 @@ let ClickEventHandler = {
       return;
     }
 
-    Cc["@mozilla.org/eventlistenerservice;1"]
-      .getService(Ci.nsIEventListenerService)
-      .addSystemEventListener(global, "mousemove", this, true);
+    Services.els.addSystemEventListener(global, "mousemove", this, true);
     addEventListener("pagehide", this, true);
 
     this._ignoreMouseEvents = true;
@@ -148,9 +144,7 @@ let ClickEventHandler = {
     if (this._scrollable) {
       this._scrollable = null;
 
-      Cc["@mozilla.org/eventlistenerservice;1"]
-        .getService(Ci.nsIEventListenerService)
-        .removeSystemEventListener(global, "mousemove", this, true);
+      Services.els.removeSystemEventListener(global, "mousemove", this, true);
       removeEventListener("pagehide", this, true);
     }
   },

--- a/toolkit/modules/Services.jsm
+++ b/toolkit/modules/Services.jsm
@@ -36,6 +36,18 @@ XPCOMUtils.defineLazyGetter(Services, "dirsvc", function () {
            .QueryInterface(Ci.nsIProperties);
 });
 
+XPCOMUtils.defineLazyGetter(Services, "mm", () => {
+  return Cc["@mozilla.org/globalmessagemanager;1"]
+           .getService(Ci.nsIMessageBroadcaster)
+           .QueryInterface(Ci.nsIFrameScriptLoader);
+});
+
+XPCOMUtils.defineLazyGetter(Services, "ppmm", () => {
+  return Cc["@mozilla.org/parentprocessmessagemanager;1"]
+           .getService(Ci.nsIMessageBroadcaster)
+           .QueryInterface(Ci.nsIProcessScriptLoader);
+});
+
 let initTable = [
 #ifdef MOZ_WIDGET_ANDROID
   ["androidBridge", "@mozilla.org/android/bridge;1", "nsIAndroidBridge"],
@@ -43,11 +55,13 @@ let initTable = [
   ["appShell", "@mozilla.org/appshell/appShellService;1", "nsIAppShellService"],
   ["cache", "@mozilla.org/network/cache-service;1", "nsICacheService"],
   ["cache2", "@mozilla.org/netwerk/cache-storage-service;1", "nsICacheStorageService"],
+  ["cpmm", "@mozilla.org/childprocessmessagemanager;1", "nsIMessageSender"],
   ["console", "@mozilla.org/consoleservice;1", "nsIConsoleService"],
   ["contentPrefs", "@mozilla.org/content-pref/service;1", "nsIContentPrefService"],
   ["cookies", "@mozilla.org/cookiemanager;1", "nsICookieManager2"],
   ["downloads", "@mozilla.org/download-manager;1", "nsIDownloadManager"],
   ["droppedLinkHandler", "@mozilla.org/content/dropped-link-handler;1", "nsIDroppedLinkHandler"],
+  ["els", "@mozilla.org/eventlistenerservice;1", "nsIEventListenerService"],
   ["eTLD", "@mozilla.org/network/effective-tld-service;1", "nsIEffectiveTLDService"],
   ["io", "@mozilla.org/network/io-service;1", "nsIIOService2"],
   ["locale", "@mozilla.org/intl/nslocaleservice;1", "nsILocaleService"],


### PR DESCRIPTION
__The suggestion__

Forward compatibility for addons (at least partially).

Ad Greasemonkey - see [this commit](https://github.com/greasemonkey/greasemonkey/commit/34c6da5dad2e53b71015138494fda0e882da8560#commitcomment-10944861).
Ad Adblock Plus (e.g.) - see [this commit](http://outbound.palemoon.org/s/hg.adblockplus.org/elemhidehelper%2Frev%2F6c50b1badf3c).

This commit is reverted. For the time being...

See ["Pale Moon Forum" - "Ad: The Firefox addon Greasemonkey 3.8 (the original version)" - item number 4](https://forum.palemoon.org/viewtopic.php?f=56&t=12557#p88566)

See also [bug 1068087](https://bugzilla.mozilla.org/show_bug.cgi?id=1068087) / [bug 1133981](https://bugzilla.mozilla.org/show_bug.cgi?id=1133981).

Thank you in advance (if my suggestion is acceptable).
