### PR TITLE
Win10 Toolkit Theme Changes

### DIFF
--- a/browser/themes/windows/downloads/allDownloadsViewOverlay.css
+++ b/browser/themes/windows/downloads/allDownloadsViewOverlay.css
@@ -13,16 +13,11 @@
 }
 
 .downloadTypeIcon {
+  -moz-margin-start: 8px;
   -moz-margin-end: 8px;
   /* explicitly size the icon, so size doesn't vary on hidpi systems */
   height: 32px;
   width: 32px;
-}
-
-@media not all and (-moz-os-version: windows-xp) {
-  .downloadTypeIcon {
-    -moz-margin-start: 8px;
-  }
 }
 
 .blockedIcon {
@@ -101,32 +96,30 @@ richlistitem.download:hover > .downloadButton.downloadRetry:active {
   -moz-image-region: rect(32px, 64px, 48px, 48px);
 }
 
-@media not all and (-moz-os-version: windows-xp) {
-  @media (-moz-windows-default-theme) {
-    /*
-    -moz-appearance: menuitem is almost right, but the hover effect is not
-    transparent and is lighter than desired.
+@media (-moz-windows-default-theme) {
+  /*
+  -moz-appearance: menuitem is almost right, but the hover effect is not
+  transparent and is lighter than desired.
 
-    Copied from the autocomplete richlistbox styling in
-    toolkit/themes/windows/global/autocomplete.css
+  Copied from the autocomplete richlistbox styling in
+  toolkit/themes/windows/global/autocomplete.css
 
-    This styling should be kept in sync with the style from the above file.
-    */
-    #downloadsRichListBox > richlistitem.download[selected] {
-      color: inherit;
-      background-color: transparent;
-      /* four gradients for the bevel highlights on each edge, one for blue background */
-      background-image:
-        linear-gradient(to bottom, rgba(255,255,255,0.9) 3px, transparent 3px),
-        linear-gradient(to right, rgba(255,255,255,0.5) 3px, transparent 3px),
-        linear-gradient(to left, rgba(255,255,255,0.5) 3px, transparent 3px),
-        linear-gradient(to top, rgba(255,255,255,0.4) 3px, transparent 3px),
-        linear-gradient(to bottom, rgba(163,196,247,0.3), rgba(122,180,246,0.3));
-      background-clip: content-box;
-      border-radius: 6px;
-      outline: 1px solid rgb(124,163,206);
-      -moz-outline-radius: 3px;
-      outline-offset: -2px;
-    }
+  This styling should be kept in sync with the style from the above file.
+  */
+  #downloadsRichListBox > richlistitem.download[selected] {
+    color: inherit;
+    background-color: transparent;
+    /* four gradients for the bevel highlights on each edge, one for blue background */
+    background-image:
+      linear-gradient(to bottom, rgba(255,255,255,0.9) 3px, transparent 3px),
+      linear-gradient(to right, rgba(255,255,255,0.5) 3px, transparent 3px),
+      linear-gradient(to left, rgba(255,255,255,0.5) 3px, transparent 3px),
+      linear-gradient(to top, rgba(255,255,255,0.4) 3px, transparent 3px),
+      linear-gradient(to bottom, rgba(163,196,247,0.3), rgba(122,180,246,0.3));
+    background-clip: content-box;
+    border-radius: 6px;
+    outline: 1px solid rgb(124,163,206);
+    -moz-outline-radius: 3px;
+    outline-offset: -2px;
   }
 }

--- a/browser/themes/windows/pageInfo.css
+++ b/browser/themes/windows/pageInfo.css
@@ -123,7 +123,7 @@ groupbox.collapsable caption .caption-icon {
   background-position: center;
   -moz-margin-start: 2px;
   -moz-margin-end: 2px;
-  background-image: url("chrome://global/skin/tree/twisty-open.png");
+  background-image: url("chrome://global/skin/tree/twisty.svg#open");
 }
 
 groupbox.collapsable[closed="true"] {
@@ -133,7 +133,7 @@ groupbox.collapsable[closed="true"] {
 }
 
 groupbox.collapsable[closed="true"] caption .caption-icon { 
-  background-image: url("chrome://global/skin/tree/twisty-clsd.png");
+  background-image: url("chrome://global/skin/tree/twisty.svg#clsd");
 }
 
 groupbox tree { 
@@ -148,6 +148,16 @@ groupbox tree {
 #general-security-identity {
   white-space: pre-wrap;
   line-height: 2em;
+}
+
+@media (-moz-os-version: windows-win10) {
+  groupbox.collapsable caption .caption-icon {
+    background-image: url("chrome://global/skin/tree/twisty-10.svg#open");
+  }
+  
+  groupbox.collapsable[closed="true"] caption .caption-icon { 
+    background-image: url("chrome://global/skin/tree/twisty-10.svg#clsd");
+  }
 }
 
 /* Media Tab */

--- a/browser/themes/windows/places/organizer.css
+++ b/browser/themes/windows/places/organizer.css
@@ -176,34 +176,32 @@
   -moz-padding-end: 9px;
 }
 
-@media not all and (-moz-os-version: windows-xp) {
-  #placesView {
-    border-top: none;
+#placesView {
+  border-top: none;
+}
+
+@media not all and (-moz-windows-classic) {
+  #placesToolbox {
+    -moz-appearance: none;
+    background-color: transparent;
   }
 
-  @media not all and (-moz-windows-classic) {
-    #placesToolbox {
-      -moz-appearance: none;
-      background-color: transparent;
-    }
-
-    #placesToolbar {
-      -moz-appearance: none;
-      background-color: -moz-Dialog;
-      color: -moz-dialogText;
-    }
+  #placesToolbar {
+    -moz-appearance: none;
+    background-color: -moz-Dialog;
+    color: -moz-dialogText;
   }
+}
 
-  @media (-moz-windows-default-theme) {
-    #placesView > splitter {
-      border: 0;
-      -moz-border-end: 1px solid #A9B7C9;
-      min-width: 0;
-      width: 3px;
-      background-color: transparent;
-      -moz-margin-start: -3px;
-      position: relative;
-    }
+@media (-moz-windows-default-theme) {
+  #placesView > splitter {
+    border: 0;
+    -moz-border-end: 1px solid #A9B7C9;
+    min-width: 0;
+    width: 3px;
+    background-color: transparent;
+    -moz-margin-start: -3px;
+    position: relative;
   }
 }
 

--- a/browser/themes/windows/places/places.css
+++ b/browser/themes/windows/places/places.css
@@ -24,21 +24,19 @@
   cursor: default;
 }
 
-@media not all and (-moz-os-version: windows-xp) {
-  @media (-moz-windows-default-theme) {
-    #bookmarksPanel,
-    #history-panel {
-      background-color: #EEF3FA;
-    }
+@media (-moz-windows-default-theme) {
+  #bookmarksPanel,
+  #history-panel {
+    background-color: #EEF3FA;
+  }
 
-    .sidebar-placesTree {
-      background-color: transparent;
-      border-top: none;
-    }
+  .sidebar-placesTree {
+    background-color: transparent;
+    border-top: none;
+  }
 
-    .sidebar-placesTreechildren::-moz-tree-cell-text(leaf, hover) {
-      text-decoration: none;
-    }
+  .sidebar-placesTreechildren::-moz-tree-cell-text(leaf, hover) {
+    text-decoration: none;
   }
 }
 

--- a/toolkit/themes/windows/global/autocomplete.css
+++ b/toolkit/themes/windows/global/autocomplete.css
@@ -106,28 +106,26 @@ treechildren.autocomplete-treebody::-moz-tree-cell-text(selected) {
 }
 
 %ifdef XP_WIN
-@media not all and (-moz-os-version: windows-xp) {
-  @media (-moz-windows-default-theme) {
-    /*
-    -moz-appearance: menuitem is almost right, but the hover effect is not
-    transparent and is lighter than desired.
-    */
-    .autocomplete-richlistitem[selected="true"] {
-      color: inherit;
-      background-color: transparent;
-      /* four gradients for the bevel highlights on each edge, one for blue background */
-      background-image:
-        linear-gradient(to bottom, rgba(255,255,255,0.9) 3px, transparent 3px),
-        linear-gradient(to right, rgba(255,255,255,0.5) 3px, transparent 3px),
-        linear-gradient(to left, rgba(255,255,255,0.5) 3px, transparent 3px),
-        linear-gradient(to top, rgba(255,255,255,0.4) 3px, transparent 3px),
-        linear-gradient(to bottom, rgba(163,196,247,0.3), rgba(122,180,246,0.3));
-      background-clip: content-box;
-      border-radius: 6px;
-      outline: 1px solid rgb(124,163,206);
-      -moz-outline-radius: 3px;
-      outline-offset: -2px;
-    }
+@media (-moz-windows-default-theme) {
+  /*
+  -moz-appearance: menuitem is almost right, but the hover effect is not
+  transparent and is lighter than desired.
+  */
+  .autocomplete-richlistitem[selected="true"] {
+    color: inherit;
+    background-color: transparent;
+    /* four gradients for the bevel highlights on each edge, one for blue background */
+    background-image:
+      linear-gradient(to bottom, rgba(255,255,255,0.9) 3px, transparent 3px),
+      linear-gradient(to right, rgba(255,255,255,0.5) 3px, transparent 3px),
+      linear-gradient(to left, rgba(255,255,255,0.5) 3px, transparent 3px),
+      linear-gradient(to top, rgba(255,255,255,0.4) 3px, transparent 3px),
+      linear-gradient(to bottom, rgba(163,196,247,0.3), rgba(122,180,246,0.3));
+    background-clip: content-box;
+    border-radius: 6px;
+    outline: 1px solid rgb(124,163,206);
+    -moz-outline-radius: 3px;
+    outline-offset: -2px;
   }
 }
 %endif
@@ -210,19 +208,9 @@ html|span.ac-emphasize-text {
 }
 
 @media (-moz-windows-default-theme) {
-  @media not all and (-moz-os-version: windows-xp) {
-    html|span.ac-emphasize-text {
-      box-shadow: inset 0 0 1px 1px rgba(0,0,0,0.1);
-      background-color: rgba(0,0,0,0.05);
-    }
-  }
-
-  @media (-moz-os-version: windows-xp) {
-    .ac-url-text > html|span.ac-emphasize-text,
-    .ac-action-text > html|span.ac-emphasize-text {
-      box-shadow: inset 0 0 1px 1px rgba(202,214,201,0.3);
-      background-color: rgba(202,214,201,0.2);
-    }
+  html|span.ac-emphasize-text {
+    box-shadow: inset 0 0 1px 1px rgba(0,0,0,0.1);
+    background-color: rgba(0,0,0,0.05);
   }
 }
 

--- a/toolkit/themes/windows/global/button.css
+++ b/toolkit/themes/windows/global/button.css
@@ -138,11 +138,21 @@ button[type="disclosure"] {
   margin: 0px !important;
   padding: 0px !important;
   -moz-appearance: none;
-  list-style-image: url("chrome://global/skin/tree/twisty-clsd.png");
+  list-style-image: url("chrome://global/skin/tree/twisty.svg#clsd");
   min-width: 0px !important;
   background-color: transparent;
 }
 
 button[type="disclosure"][open="true"] {
-  list-style-image: url("chrome://global/skin/tree/twisty-open.png");
+  list-style-image: url("chrome://global/skin/tree/twisty.svg#open");
+}
+
+@media (-moz-os-version: windows-win10) {
+  button[type="disclosure"] {
+    list-style-image: url("chrome://global/skin/tree/twisty-10.svg#clsd");
+  }
+  
+  button[type="disclosure"][open="true"] {
+    list-style-image: url("chrome://global/skin/tree/twisty-10.svg#open");
+  }
 }

--- a/toolkit/themes/windows/global/console/console.css
+++ b/toolkit/themes/windows/global/console/console.css
@@ -208,13 +208,11 @@ toolbar#ToolbarMode .toolbarbutton-text {
 }
 
 %ifdef XP_WIN
-@media not all and (-moz-os-version: windows-xp) {
-  #ToolbarMode {
-    -moz-appearance: -moz-win-browsertabbar-toolbox;
-  }
+#ToolbarMode {
+  -moz-appearance: -moz-win-browsertabbar-toolbox;
+}
 
-  #ToolbarEval {
-    -moz-appearance: toolbox;
-  }
+#ToolbarEval {
+  -moz-appearance: toolbox;
 }
 %endif

--- a/toolkit/themes/windows/global/inContentUI.css
+++ b/toolkit/themes/windows/global/inContentUI.css
@@ -76,8 +76,7 @@ html|html {
 }
 
 %ifdef XP_WIN
-@media (-moz-os-version: windows-xp),
-       (-moz-os-version: windows-vista),
+@media (-moz-os-version: windows-vista),
        (-moz-os-version: windows-win7) {
 %endif
   *|*.main-content {

--- a/toolkit/themes/windows/global/jar.mn
+++ b/toolkit/themes/windows/global/jar.mn
@@ -211,3 +211,5 @@ toolkit.jar:
         skin/classic/global/tree/twisty-open-rtl.png             (tree/twisty-open-rtl.png)
         skin/classic/global/tree/twisty-open-hover.png           (tree/twisty-open-hover.png)
         skin/classic/global/tree/twisty-open-hover-rtl.png       (tree/twisty-open-hover-rtl.png)
+        skin/classic/global/tree/twisty.svg                      (tree/twisty.svg)
+        skin/classic/global/tree/twisty-10.svg                   (tree/twisty-10.svg)

--- a/toolkit/themes/windows/global/jar.mn
+++ b/toolkit/themes/windows/global/jar.mn
@@ -31,7 +31,7 @@ toolkit.jar:
         skin/classic/global/groupbox.css
 *       skin/classic/global/inContentUI.css
         skin/classic/global/linkTree.css
-*       skin/classic/global/listbox.css
+        skin/classic/global/listbox.css
 *       skin/classic/global/menu.css
         skin/classic/global/menulist.css
         skin/classic/global/netError.css

--- a/toolkit/themes/windows/global/listbox.css
+++ b/toolkit/themes/windows/global/listbox.css
@@ -6,15 +6,7 @@
   == Styles used by XUL listbox-related elements.
   ======================================================================= */
 
-%filter substitution
-%define selectedBorderColor rgb(217,217,217)
-%define hoverAndFocusBorderColor rgb(125,162,206)
-%define selectedFocusBorderColor rgb(132,172,221)
-%define selectedGradientColor1 rgba(190,190,190,.1)
-%define selectedGradientColor2 rgba(190,190,190,.4)
-%define selectedFocusGradientColor1 rgba(131,183,249,.16)
-%define selectedFocusGradientColor2 rgba(131,183,249,.375)
-  
+
 @namespace url("http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul");
 
 /* ::::: listbox ::::: */
@@ -62,7 +54,7 @@ listbox:focus > listitem[selected="true"] {
 
 /* ::::: listheader ::::: */
 
-listheader { 
+listheader {
   -moz-appearance: treeheadercell;
   -moz-box-align: center;
   border: 2px solid;
@@ -153,6 +145,21 @@ listheader[sortable="true"]:hover:active {
 
 @media (-moz-windows-default-theme) {
   listitem {
+    --listitem-selectedColor: rgb(217,217,217);
+    --listitem-selectedBorder: var(--listitem-selectedColor);
+    --listitem-selectedBottomBorder: rgb(204,204,204);
+    --listitem-selectedBackground: var(--listitem-selectedColor);
+    --listitem-selectedImage: none;
+    --listitem-selectedCurrentBorder: rgb(123,195,255);
+    --listitem-selectedFocusColor: rgb(205,232,255);
+    --listitem-selectedFocusBorder: var(--listitem-selectedFocusColor);
+    --listitem-selectedFocusBottomBorder: rgb(165,214,255);
+    --listitem-selectedFocusBackground: var(--listitem-selectedFocusColor);
+    --listitem-selectedFocusImage: none;
+    --listitem-selectedFocusCurrentBorder: var(--listitem-selectedFocusColor);
+    --listitem-selectedFocusCurrentBottomBorder: var(--listitem-selectedFocusBottomBorder);
+    --listitem-selectedFocusCurrentBackground: var(--listitem-selectedFocusColor);
+
     color: -moz-FieldText;
     -moz-margin-start: 1px;
     -moz-margin-end: 1px;
@@ -164,42 +171,68 @@ listheader[sortable="true"]:hover:active {
   }
 
   listitem[selected="true"] {
-    border-color: @selectedBorderColor@;
-    background-image: linear-gradient(@selectedGradientColor2@, @selectedGradientColor2@);
-    background-color: rgba(190,190,190,.15);
+    border-top-color: var(--listitem-selectedBorder);
+    border-right-color: var(--listitem-selectedBorder);
+    border-left-color: var(--listitem-selectedBorder);
+    border-bottom-color: var(--listitem-selectedBottomBorder);
+    background-image: var(--listitem-selectedImage);
+    background-color: var(--listitem-selectedBackground);
     color: -moz-DialogText;
   }
 
   listbox:focus > listitem[selected="true"] {
-    border-color: @selectedFocusBorderColor@;
-    background-image: linear-gradient(@selectedFocusGradientColor2@, @selectedFocusGradientColor2@);
-    background-color: rgba(131,183,249,.02);
+    border-top-color: var(--listitem-selectedFocusBorder);
+    border-right-color: var(--listitem-selectedFocusBorder);
+    border-left-color: var(--listitem-selectedFocusBorder);
+    border-bottom-color: var(--listitem-selectedFocusBottomBorder);
+    background-image: var(--listitem-selectedFocusImage);
+    background-color: var(--listitem-selectedFocusBackground);
     color: -moz-DialogText;
   }
 
   listbox:focus > listitem[current="true"] {
-    border-color: @hoverAndFocusBorderColor@;
+    border-color: var(--listitem-selectedCurrentBorder);
     outline: none;
   }
 
   listbox:focus > listitem[selected="true"][current="true"] {
-    background-color: rgba(131,183,249,.15);
+    border-top-color: var(--listitem-selectedFocusCurrentBorder);
+    border-right-color: var(--listitem-selectedFocusCurrentBorder);
+    border-left-color: var(--listitem-selectedFocusCurrentBorder);
+    border-bottom-color: var(--listitem-selectedFocusCurrentBottomBorder);
+    background-color: var(--listitem-selectedFocusCurrentBackground);
     outline: none;
   }
 
   @media (-moz-os-version: windows-vista),
          (-moz-os-version: windows-win7) {
     listitem {
+      --listitem-selectedBottomBorder: var(--listitem-selectedColor);
+      --listitem-selectedBackground: rgba(190,190,190,.15);
+      --listitem-selectedImage: linear-gradient(rgba(190,190,190,.1), rgba(190,190,190,.4));
+      --listitem-selectedCurrentBorder: rgb(125,162,206);
+      --listitem-selectedFocusColor: rgb(132,172,221);
+      --listitem-selectedFocusBottomBorder: var(--listitem-selectedFocusColor);
+      --listitem-selectedFocusBackground: rgba(131,183,249,.02);
+      --listitem-selectedFocusImage: linear-gradient(rgba(131,183,249,.16), rgba(131,183,249,.375));
+      --listitem-selectedFocusCurrentBackground: rgba(131,183,249,.15);
+
       border-radius: 3px;
       box-shadow: inset 0 0 0 1px rgba(255,255,255,.4), inset 0 -1px 0 1px rgba(255,255,255,.2);
     }
+  }
 
-    listitem[selected="true"] {
-      background-image: linear-gradient(@selectedGradientColor1@, @selectedGradientColor2@);
-    }
-
-    listbox:focus > listitem[selected="true"] {
-      background-image: linear-gradient(@selectedFocusGradientColor1@, @selectedFocusGradientColor2@);
+  @media (-moz-os-version: windows-win8) {
+    listitem {
+      --listitem-selectedBottomBorder: var(--listitem-selectedColor);
+      --listitem-selectedBackground: rgba(190,190,190,.15);
+      --listitem-selectedImage: linear-gradient(rgba(190,190,190,.4), rgba(190,190,190,.4));
+      --listitem-selectedCurrentBorder: rgb(125,162,206);
+      --listitem-selectedFocusColor: rgb(132,172,221);
+      --listitem-selectedFocusBottomBorder: var(--listitem-selectedFocusColor);
+      --listitem-selectedFocusBackground: rgba(131,183,249,.02);
+      --listitem-selectedFocusImage: linear-gradient(rgba(131,183,249,.375), rgba(131,183,249,.375));
+      --listitem-selectedFocusCurrentBackground: rgba(131,183,249,.15);
     }
   }
 }

--- a/toolkit/themes/windows/global/menu.css
+++ b/toolkit/themes/windows/global/menu.css
@@ -141,15 +141,13 @@ menubar > menu:-moz-lwtheme[_moz-menuactive="true"]:not([disabled="true"]) {
 }
 
 @media (-moz-windows-default-theme) {
-  @media not all and (-moz-os-version: windows-xp) {
-    menubar > menu:-moz-lwtheme {
-      -moz-appearance: menuitem;
-    }
+  menubar > menu:-moz-lwtheme {
+    -moz-appearance: menuitem;
+  }
 
-    menubar > menu:-moz-lwtheme[_moz-menuactive="true"]:not([disabled="true"]) {
-      color: inherit !important;
-      text-shadow: inherit;
-    }
+  menubar > menu:-moz-lwtheme[_moz-menuactive="true"]:not([disabled="true"]) {
+    color: inherit !important;
+    text-shadow: inherit;
   }
 }
 

--- a/toolkit/themes/windows/global/menulist.css
+++ b/toolkit/themes/windows/global/menulist.css
@@ -82,12 +82,6 @@ menulist:-moz-focusring:not([open="true"]) > .menulist-label-box {
   border: 1px dotted ThreeDDarkShadow;
 }
 
-@media (-moz-os-version: windows-xp) {
-  menulist:-moz-focusring:not([open="true"]) > .menulist-label-box {
-    border: 1px dotted #F5DB95;
-  }
-}
-
 /* ..... disabled state ..... */
 
 menulist[disabled="true"] {
@@ -113,31 +107,29 @@ html|*.menulist-editable-input {
 }
 
 @media (-moz-windows-default-theme) {
-  @media not all and (-moz-os-version: windows-xp) {
-    .menulist-label-box {
-      background-color: transparent !important;
-      color: inherit !important;
-    }
+  .menulist-label-box {
+    background-color: transparent !important;
+    color: inherit !important;
+  }
 
-    .menulist-label {
-      margin-top: -1px !important;
-      margin-bottom: -1px !important;
-      -moz-margin-start: 0 !important;
-    }
+  .menulist-label {
+    margin-top: -1px !important;
+    margin-bottom: -1px !important;
+    -moz-margin-start: 0 !important;
+  }
 
-    .menulist-description {
-      -moz-margin-start: 1ex !important;
-    }
+  .menulist-description {
+    -moz-margin-start: 1ex !important;
+  }
 
-    menulist:not([editable="true"]) > .menulist-dropmarker {
-      margin-top: -2px;
-      -moz-margin-start: 3px;
-      -moz-margin-end: -3px;
-    }
+  menulist:not([editable="true"]) > .menulist-dropmarker {
+    margin-top: -2px;
+    -moz-margin-start: 3px;
+    -moz-margin-end: -3px;
+  }
 
-    .menulist-icon {
-      margin-top: -1px;
-      margin-bottom: -1px;
-    }
+  .menulist-icon {
+    margin-top: -1px;
+    margin-bottom: -1px;
   }
 }

--- a/toolkit/themes/windows/global/popup.css
+++ b/toolkit/themes/windows/global/popup.css
@@ -64,8 +64,7 @@ panel[type="arrow"][side="right"] {
 }
 
 %ifdef XP_WIN
-@media (-moz-os-version: windows-xp),
-       (-moz-os-version: windows-vista),
+@media (-moz-os-version: windows-vista),
        (-moz-os-version: windows-win7) {
 %endif
 /* < Win8 */

--- a/toolkit/themes/windows/global/textbox.css
+++ b/toolkit/themes/windows/global/textbox.css
@@ -37,10 +37,8 @@ html|*.textbox-textarea {
 }
 
 @media (-moz-windows-default-theme) {
-  @media not all and (-moz-os-version: windows-xp) {
-    textbox html|*.textbox-input::-moz-placeholder {
-      font-style: italic;
-    }
+  textbox html|*.textbox-input::-moz-placeholder {
+    font-style: italic;
   }
 }
 

--- a/toolkit/themes/windows/global/toolbarbutton.css
+++ b/toolkit/themes/windows/global/toolbarbutton.css
@@ -89,11 +89,9 @@ toolbarbutton[checked="true"]:not([disabled="true"]) {
     text-shadow: inherit;
   }
   
-  @media not all and (-moz-os-version: windows-xp) {
-    toolbarbutton:-moz-lwtheme:not([disabled="true"]) {
-      color: inherit;
-      text-shadow: inherit;
-    }
+  toolbarbutton:-moz-lwtheme:not([disabled="true"]) {
+    color: inherit;
+    text-shadow: inherit;
   }
 }
 

--- a/toolkit/themes/windows/global/tree.css
+++ b/toolkit/themes/windows/global/tree.css
@@ -6,22 +6,6 @@
   == Styles used by the XUL outline element.
   ======================================================================= */
 
-%filter substitution
-%define selectedBorderColor rgb(217,217,217)
-%define hoverAndFocusBorderColor rgb(125,162,206)
-%define selectedFocusBorderColor rgb(132,172,221)
-%define hoverBorderColor rgb(184,214,251)
-%define whiteOpacityBorderColor rgba(255,255,255,.4)
-%define whiteOpacityBottomBorderColor rgba(255,255,255,.6)
-%define selectedGradientColor1 rgba(190,190,190,.1)
-%define selectedGradientColor2 rgba(190,190,190,.4)
-%define selectedFocusGradientColor1 rgba(131,183,249,.16)
-%define selectedFocusGradientColor2 rgba(131,183,249,.375)
-%define hoverAndCurrentFocusGradientColor1 rgba(131,183,249,.28)
-%define hoverAndCurrentFocusGradientColor2 rgba(131,183,249,.5)
-%define hoverGradientColor1 rgba(131,183,249,.05)
-%define hoverGradientColor2 rgba(131,183,249,.16)
-  
 @namespace url("http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul");
 
 /* ::::: tree ::::: */
@@ -41,7 +25,7 @@ tree {
 /* ::::: tree focusring ::::: */
 
 .focusring > .tree-stack > .tree-rows > .tree-bodybox {
-  border: 1px solid transparent;  
+  border: 1px solid transparent;
 }
 
 .focusring:-moz-focusring > .tree-stack > .tree-rows > .tree-bodybox {
@@ -252,9 +236,7 @@ treecol[hideheader="true"] {
 treecol:hover:active,
 treecolpicker:hover:active {
   border-top: 2px solid;
-  border-right: 1px solid;
   border-bottom: 1px solid;
-  border-left: 2px solid;
   -moz-border-top-colors: ThreeDShadow -moz-Dialog;
   -moz-border-right-colors: ThreeDShadow;
   -moz-border-bottom-colors: ThreeDShadow;
@@ -262,14 +244,14 @@ treecolpicker:hover:active {
   padding-top: 1px;
   padding-bottom: 0px;
   -moz-padding-start: 5px;
-  -moz-padding-end: 4px;
+  -moz-padding-end: 3px;
 }
 
 .treecol-image:hover:active {
   padding-top: 1px;
   padding-bottom: 0px;
   -moz-padding-start: 2px;
-  -moz-padding-end: 1px;
+  -moz-padding-end: 0px;
 }
 
 /* ::::: column drag and drop styles ::::: */
@@ -335,12 +317,11 @@ treechildren::-moz-tree-twisty {
   -moz-padding-end: 4px;
   padding-top: 1px;
   width: 9px; /* The image's width is 9 pixels */
-  list-style-image: url("chrome://global/skin/tree/twisty-clsd.png");
+  list-style-image: url("chrome://global/skin/tree/twisty.svg#clsd");
 }
 
 treechildren::-moz-tree-twisty(open) {
-  width: 9px; /* The image's width is 9 pixels */
-  list-style-image: url("chrome://global/skin/tree/twisty-open.png");
+  list-style-image: url("chrome://global/skin/tree/twisty.svg#open");
 }
 
 treechildren::-moz-tree-indentation {
@@ -382,174 +363,265 @@ treechildren::-moz-tree-cell-text(selected, editing) {
 }
 
 %ifdef XP_WIN
-@media not all and (-moz-os-version: windows-xp) {
-  /* ::::: twisty :::::  */
+/* ::::: twisty :::::  */
 
-  treechildren::-moz-tree-indentation {
-    width: 12px;
-  }
+treechildren::-moz-tree-indentation {
+  width: 12px;
+}
 
+treechildren::-moz-tree-twisty {
+  -moz-padding-end: 1px;
+}
+
+treechildren::-moz-tree-twisty(hover) {
+  list-style-image: url("chrome://global/skin/tree/twisty.svg#clsd-hover");
+}
+
+treechildren::-moz-tree-twisty(hover, open) {
+  list-style-image: url("chrome://global/skin/tree/twisty.svg#open-hover");
+}
+
+treechildren:-moz-locale-dir(rtl)::-moz-tree-twisty {
+  list-style-image: url("chrome://global/skin/tree/twisty.svg#clsd-rtl");
+}
+
+treechildren:-moz-locale-dir(rtl)::-moz-tree-twisty(open) {
+  list-style-image: url("chrome://global/skin/tree/twisty.svg#open-rtl");
+}
+
+treechildren:-moz-locale-dir(rtl)::-moz-tree-twisty(hover) {
+  list-style-image: url("chrome://global/skin/tree/twisty.svg#clsd-hover-rtl");
+}
+
+treechildren:-moz-locale-dir(rtl)::-moz-tree-twisty(hover, open) {
+  list-style-image: url("chrome://global/skin/tree/twisty.svg#open-hover-rtl");
+}
+
+@media (-moz-os-version: windows-win10) {
   treechildren::-moz-tree-twisty {
-    -moz-padding-end: 1px;
-    width: 9px;
+    list-style-image: url("chrome://global/skin/tree/twisty-10.svg#clsd");
   }
 
+  treechildren::-moz-tree-twisty(open) {
+    list-style-image: url("chrome://global/skin/tree/twisty-10.svg#open");
+  }
+  
   treechildren::-moz-tree-twisty(hover) {
-    list-style-image: url("chrome://global/skin/tree/twisty-clsd-hover.png");
+    list-style-image: url("chrome://global/skin/tree/twisty-10.svg#clsd-hover");
   }
 
   treechildren::-moz-tree-twisty(hover, open) {
-    list-style-image: url("chrome://global/skin/tree/twisty-open-hover.png");
+    list-style-image: url("chrome://global/skin/tree/twisty-10.svg#open-hover");
   }
 
   treechildren:-moz-locale-dir(rtl)::-moz-tree-twisty {
-    list-style-image: url("chrome://global/skin/tree/twisty-clsd-rtl.png");
+    list-style-image: url("chrome://global/skin/tree/twisty-10.svg#clsd-rtl");
   }
 
   treechildren:-moz-locale-dir(rtl)::-moz-tree-twisty(open) {
-    list-style-image: url("chrome://global/skin/tree/twisty-open-rtl.png");
+    list-style-image: url("chrome://global/skin/tree/twisty-10.svg#open-rtl");
   }
 
   treechildren:-moz-locale-dir(rtl)::-moz-tree-twisty(hover) {
-    list-style-image: url("chrome://global/skin/tree/twisty-clsd-hover-rtl.png");
+    list-style-image: url("chrome://global/skin/tree/twisty-10.svg#clsd-hover-rtl");
   }
 
   treechildren:-moz-locale-dir(rtl)::-moz-tree-twisty(hover, open) {
-    list-style-image: url("chrome://global/skin/tree/twisty-open-hover-rtl.png");
+    list-style-image: url("chrome://global/skin/tree/twisty-10.svg#open-hover-rtl");
+  }
+}
+
+@media (-moz-windows-default-theme) {
+  treechildren {
+    --treechildren-outline: none;
+    --treechildren-2ndBorderColor: rgba(255,255,255,.4);
+    --treechildren-selectedColor: rgb(217,217,217);
+    --treechildren-focusColor: rgb(123,195,255);
+    --treechildren-selectedFocusColor: rgb(205,232,255);
+    --treechildren-currentColor: rgb(125,162,206);
+    --treechildren-hoverColor: rgb(229,243,255);
+    --treechildren-selectedBorder: var(--treechildren-selectedColor);
+    --treechildren-selectedBottomBorder: rgb(204,204,204);
+    --treechildren-selectedImage: linear-gradient(rgb(217,217,217), rgb(217,217,217));
+    --treechildren-selectedBackground: transparent;
+    --treechildren-currentFocusBorder: var(--treechildren-focusColor);
+    --treechildren-currentFocusBottomBorder: var(--treechildren-focusColor);
+    --treechildren-selectedFocusBorder: var(--treechildren-selectedFocusColor);
+    --treechildren-selectedFocusBottomBorder: rgb(165,214,255);
+    --treechildren-selectedFocusImage: none;
+    --treechildren-selectedFocusBackground: var(--treechildren-selectedFocusColor);
+    --treechildren-selectedFocusCurrentBorder: var(--treechildren-focusColor);
+    --treechildren-selectedFocusCurrentBottomBorder: var(--treechildren-focusColor);
+    --treechildren-selectedFocusCurrentImage: linear-gradient(rgb(205,232,255), rgb(205,232,255));
+    --treechildren-hoverBorder: var(--treechildren-hoverColor);
+    --treechildren-hoverBottomBorder: var(--treechildren-hoverColor);
+    --treechildren-hoverImage: linear-gradient(rgb(229,243,255), rgb(229,243,255));
+    --treechildren-hoverCurrentBorder: var(--treechildren-currentColor);
+    --treechildren-hoverCurrentBottomBorder: var(--treechildren-currentColor);
+    --treechildren-hoverCurrentImage: linear-gradient(rgba(131,183,249,.16), rgba(131,183,249,.16));
+    --treechildren-hoverSelectedBorder: var(--treechildren-focusColor);
+    --treechildren-hoverSelectedBottomBorder: var(--treechildren-focusColor);
+    --treechildren-hoverSelectedImage: linear-gradient(rgb(205,232,255), rgb(205,232,255));
   }
 
-  @media (-moz-windows-default-theme) {
+  treechildren:not(.autocomplete-treebody)::-moz-tree-row {
+    height: 1.8em;
+    color: -moz-FieldText;
+    -moz-margin-start: 1px;
+    -moz-margin-end: 1px;
+    border-width: 1px;
+    border-color: transparent;
+    background-repeat: no-repeat;
+    background-size: 100% 100%;
+  }
+
+  treechildren:not(.autocomplete-treebody)::-moz-tree-row(selected) {
+    -moz-border-top-colors: var(--treechildren-selectedBorder);
+    -moz-border-right-colors: var(--treechildren-selectedBorder);
+    -moz-border-left-colors: var(--treechildren-selectedBorder);
+    -moz-border-bottom-colors: var(--treechildren-selectedBottomBorder);
+    background-image: var(--treechildren-selectedImage);
+    background-color: var(--treechildren-selectedBackground);
+    outline: var(--treechildren-outline);
+  }
+
+  treechildren:not(.autocomplete-treebody)::-moz-tree-row(current, focus) {
+    border-style: solid;
+    -moz-border-top-colors: var(--treechildren-currentFocusBorder);
+    -moz-border-right-colors: var(--treechildren-currentFocusBorder);
+    -moz-border-left-colors: var(--treechildren-currentFocusBorder);
+    -moz-border-bottom-colors: var(--treechildren-currentFocusBottomBorder);
+    outline: var(--treechildren-outline);
+  }
+
+  treechildren:not(.autocomplete-treebody)::-moz-tree-row(selected, focus),
+  treechildren::-moz-tree-row(dropOn) {
+    -moz-border-top-colors: var(--treechildren-selectedFocusBorder);
+    -moz-border-right-colors: var(--treechildren-selectedFocusBorder);
+    -moz-border-left-colors: var(--treechildren-selectedFocusBorder);
+    -moz-border-bottom-colors: var(--treechildren-selectedFocusBottomBorder);
+    background-image: var(--treechildren-selectedFocusImage);
+    background-color: var(--treechildren-selectedFocusBackground);
+  }
+
+  treechildren:not(.autocomplete-treebody)::-moz-tree-row(selected, current, focus) {
+    border-style: solid;
+    -moz-border-top-colors: var(--treechildren-selectedFocusCurrentBorder);
+    -moz-border-right-colors: var(--treechildren-selectedFocusCurrentBorder);
+    -moz-border-left-colors: var(--treechildren-selectedFocusCurrentBorder);
+    -moz-border-bottom-colors: var(--treechildren-selectedFocusCurrentBottomBorder);
+    background-image: var(--treechildren-selectedFocusCurrentImage);
+  }
+
+  treechildren:not(.autocomplete-treebody)::-moz-tree-row(hover) {
+    -moz-border-top-colors: var(--treechildren-hoverBorder);
+    -moz-border-right-colors: var(--treechildren-hoverBorder);
+    -moz-border-left-colors: var(--treechildren-hoverBorder);
+    -moz-border-bottom-colors: var(--treechildren-hoverBottomBorder);
+    background-image: var(--treechildren-hoverImage);
+    outline: var(--treechildren-outline);
+  }
+
+  treechildren:not(.autocomplete-treebody)::-moz-tree-row(hover, current) {
+    -moz-border-top-colors: var(--treechildren-hoverCurrentBorder);
+    -moz-border-right-colors: var(--treechildren-hoverCurrentBorder);
+    -moz-border-left-colors: var(--treechildren-hoverCurrentBorder);
+    -moz-border-bottom-colors: var(--treechildren-hoverCurrentBottomBorder);
+    background-image: var(--treechildren-hoverCurrentImage);
+  }
+
+  treechildren:not(.autocomplete-treebody)::-moz-tree-row(hover, selected) {
+    -moz-border-top-colors: var(--treechildren-hoverSelectedBorder);
+    -moz-border-right-colors: var(--treechildren-hoverSelectedBorder);
+    -moz-border-left-colors: var(--treechildren-hoverSelectedBorder);
+    -moz-border-bottom-colors: var(--treechildren-hoverSelectedBottomBorder);
+    background-image: var(--treechildren-hoverSelectedImage);
+  }
+
+  tree[disabled="true"] > treechildren::-moz-tree-row {
+    background: none;
+    -moz-border-top-colors: transparent;
+    -moz-border-right-colors: transparent;
+    -moz-border-left-colors: transparent;
+    -moz-border-bottom-colors: transparent;
+  }
+
+  treechildren::-moz-tree-cell(dropOn) {
+    background-image: none;
+    background-color: transparent;
+    border-radius: 0;
+  }
+
+  treechildren::-moz-tree-cell-text(primary, dropOn) {
+    color: -moz-FieldText;
+  }
+
+  treechildren:not(.autocomplete-treebody)::-moz-tree-cell-text {
+    padding-bottom: initial;
+    border-color: transparent;
+    background-color: transparent;
+  }
+
+  treechildren:not(.autocomplete-treebody)::-moz-tree-cell-text(selected, focus) {
+    color: -moz-DialogText;
+  }
+
+  @media (-moz-os-version: windows-vista),
+         (-moz-os-version: windows-win7) {
+    treechildren {
+      --treechildren-outline: 1px solid var(--treechildren-2ndBorderColor);
+      --treechildren-2ndBottomBorderColor: rgba(255,255,255,.6);
+      --treechildren-selectedBorder: var(--treechildren-selectedColor) var(--treechildren-2ndBorderColor);
+      --treechildren-selectedBottomBorder: var(--treechildren-selectedColor) var(--treechildren-2ndBottomBorderColor);
+      --treechildren-selectedImage: linear-gradient(rgba(190,190,190,.1), rgba(190,190,190,.4));
+      --treechildren-currentFocusBorder: var(--treechildren-currentColor) var(--treechildren-2ndBorderColor);
+      --treechildren-currentFocusBottomBorder: var(--treechildren-currentColor) var(--treechildren-2ndBottomBorderColor);
+      --treechildren-selectedFocusBorder: rgb(132,172,221) var(--treechildren-2ndBorderColor);
+      --treechildren-selectedFocusBottomBorder: var(--treechildren-currentColor) var(--treechildren-2ndBottomBorderColor);
+      --treechildren-selectedFocusImage: linear-gradient(rgba(131,183,249,.16), rgba(131,183,249,.375));
+      --treechildren-selectedFocusBackground: transparent;
+      --treechildren-selectedFocusCurrentBorder: var(--treechildren-currentColor) var(--treechildren-2ndBorderColor);
+      --treechildren-selectedFocusCurrentBottomBorder: var(--treechildren-currentColor) var(--treechildren-2ndBottomBorderColor);
+      --treechildren-selectedFocusCurrentImage: linear-gradient(rgba(131,183,249,.28), rgba(131,183,249,.5));
+      --treechildren-hoverBorder: rgb(184,214,251) var(--treechildren-2ndBorderColor);
+      --treechildren-hoverBottomBorder: rgb(184,214,251) var(--treechildren-2ndBottomBorderColor);
+      --treechildren-hoverImage: linear-gradient(rgba(131,183,249,.05), rgba(131,183,249,.16));
+      --treechildren-hoverCurrentBorder: var(--treechildren-currentColor) var(--treechildren-2ndBorderColor);
+      --treechildren-hoverCurrentBottomBorder: var(--treechildren-currentColor) var(--treechildren-2ndBottomBorderColor);
+      --treechildren-hoverCurrentImage: linear-gradient(rgba(131,183,249,.05), rgba(131,183,249,.16));
+      --treechildren-hoverSelectedBorder: var(--treechildren-currentColor) var(--treechildren-2ndBorderColor);
+      --treechildren-hoverSelectedBottomBorder: var(--treechildren-currentColor) var(--treechildren-2ndBottomBorderColor);
+      --treechildren-hoverSelectedImage: linear-gradient(rgba(131,183,249,.28), rgba(131,183,249,.5));
+    }
+
     treechildren:not(.autocomplete-treebody)::-moz-tree-row {
-      height: 1.8em;
-      color: -moz-FieldText;
-      -moz-margin-start: 1px;
-      -moz-margin-end: 1px;
       border-width: 2px;
-      border-color: transparent;
       border-radius: 3px;
-      background-repeat: no-repeat;
-      background-size: 100% 100%;
       -moz-outline-radius: 3px;
     }
+  }
 
-    treechildren:not(.autocomplete-treebody)::-moz-tree-row(selected) {
-      -moz-border-top-colors: @selectedBorderColor@ @whiteOpacityBorderColor@;
-      -moz-border-right-colors: @selectedBorderColor@ @whiteOpacityBorderColor@;
-      -moz-border-left-colors: @selectedBorderColor@ @whiteOpacityBorderColor@;
-      -moz-border-bottom-colors: @selectedBorderColor@ @whiteOpacityBottomBorderColor@;
-      background-image: linear-gradient(@selectedGradientColor1@, @selectedGradientColor2@);
-      background-color: transparent;
-      outline: 1px solid @whiteOpacityBorderColor@;
-    }
-
-    treechildren:not(.autocomplete-treebody)::-moz-tree-row(current, focus) {
-      border-style: solid;
-      -moz-border-top-colors: @hoverAndFocusBorderColor@ @whiteOpacityBorderColor@;
-      -moz-border-right-colors: @hoverAndFocusBorderColor@ @whiteOpacityBorderColor@;
-      -moz-border-left-colors: @hoverAndFocusBorderColor@ @whiteOpacityBorderColor@;
-      -moz-border-bottom-colors: @hoverAndFocusBorderColor@ @whiteOpacityBottomBorderColor@;
-      outline: 1px solid @whiteOpacityBorderColor@;
-    }
-
-    treechildren:not(.autocomplete-treebody)::-moz-tree-row(selected, focus),
-    treechildren::-moz-tree-row(dropOn) {
-      -moz-border-top-colors: @selectedFocusBorderColor@ @whiteOpacityBorderColor@;
-      -moz-border-right-colors: @selectedFocusBorderColor@ @whiteOpacityBorderColor@;
-      -moz-border-left-colors: @selectedFocusBorderColor@ @whiteOpacityBorderColor@;
-      -moz-border-bottom-colors: @selectedFocusBorderColor@ @whiteOpacityBottomBorderColor@;
-      background-image: linear-gradient(@selectedFocusGradientColor1@, @selectedFocusGradientColor2@);
-      background-color: transparent;
-    }
-
-    treechildren:not(.autocomplete-treebody)::-moz-tree-row(selected, current, focus) {
-      border-style: solid;
-      -moz-border-top-colors: @hoverAndFocusBorderColor@ @whiteOpacityBorderColor@;
-      -moz-border-right-colors: @hoverAndFocusBorderColor@ @whiteOpacityBorderColor@;
-      -moz-border-left-colors: @hoverAndFocusBorderColor@ @whiteOpacityBorderColor@;
-      -moz-border-bottom-colors: @hoverAndFocusBorderColor@ @whiteOpacityBottomBorderColor@;
-      background-image: linear-gradient(@hoverAndCurrentFocusGradientColor1@, @hoverAndCurrentFocusGradientColor2@);
-    }
-
-    treechildren:not(.autocomplete-treebody)::-moz-tree-row(hover) {
-      -moz-border-top-colors: @hoverBorderColor@ @whiteOpacityBorderColor@;
-      -moz-border-right-colors: @hoverBorderColor@ @whiteOpacityBorderColor@;
-      -moz-border-left-colors: @hoverBorderColor@ @whiteOpacityBorderColor@;
-      -moz-border-bottom-colors: @hoverBorderColor@ @whiteOpacityBottomBorderColor@;
-      background-image: linear-gradient(@hoverGradientColor1@, @hoverGradientColor2@);
-      outline: 1px solid @whiteOpacityBorderColor@;
-    }
-
-    treechildren:not(.autocomplete-treebody)::-moz-tree-row(hover, current) {
-      -moz-border-top-colors: @hoverAndFocusBorderColor@ @whiteOpacityBorderColor@;
-      -moz-border-right-colors: @hoverAndFocusBorderColor@ @whiteOpacityBorderColor@;
-      -moz-border-left-colors: @hoverAndFocusBorderColor@ @whiteOpacityBorderColor@;
-      -moz-border-bottom-colors: @hoverAndFocusBorderColor@ @whiteOpacityBottomBorderColor@;
-      background-image: linear-gradient(@hoverGradientColor1@, @hoverGradientColor2@);
-    }
-
-    treechildren:not(.autocomplete-treebody)::-moz-tree-row(hover, selected) {
-      -moz-border-top-colors: @hoverAndFocusBorderColor@ @whiteOpacityBorderColor@;
-      -moz-border-right-colors: @hoverAndFocusBorderColor@ @whiteOpacityBorderColor@;
-      -moz-border-left-colors: @hoverAndFocusBorderColor@ @whiteOpacityBorderColor@;
-      -moz-border-bottom-colors: @hoverAndFocusBorderColor@ @whiteOpacityBottomBorderColor@;
-      background-image: linear-gradient(@hoverAndCurrentFocusGradientColor1@, @hoverAndCurrentFocusGradientColor2@);
-    }
-
-    tree[disabled="true"] > treechildren::-moz-tree-row {
-      background: none;
-      -moz-border-top-colors: transparent;
-      -moz-border-right-colors: transparent;
-      -moz-border-left-colors: transparent;
-      -moz-border-bottom-colors: transparent;
-    }
-
-    treechildren::-moz-tree-cell(dropOn) {
-      background-image: none;
-      background-color: transparent;
-      border-radius: 0;
-    }
-
-    treechildren:not(.autocomplete-treebody)::-moz-tree-cell-text {
-      padding-bottom: initial;
-      border-color: transparent;
-      background-color: transparent;
-    }
-
-    treechildren:not(.autocomplete-treebody)::-moz-tree-cell-text(selected, focus) {
-      color: -moz-DialogText;
-    }
-
-    @media (-moz-os-version: windows-win8) {
-      treechildren:not(.autocomplete-treebody)::-moz-tree-row {
-        border-width: 1px;
-        border-radius: 0;
-        -moz-outline-radius: 0;
-      }
-
-      treechildren:not(.autocomplete-treebody)::-moz-tree-row(selected) {
-        background-image: linear-gradient(@selectedGradientColor2@, @selectedGradientColor2@);
-      }
-
-      treechildren:not(.autocomplete-treebody)::-moz-tree-row(selected, focus),
-      treechildren::-moz-tree-row(dropOn) {
-        background-image: linear-gradient(@selectedFocusGradientColor2@, @selectedFocusGradientColor2@);
-      }
-
-      treechildren:not(.autocomplete-treebody)::-moz-tree-row(selected, current, focus) {
-        background-image: linear-gradient(@hoverAndCurrentFocusGradientColor2@, @hoverAndCurrentFocusGradientColor2@);
-      }
-
-      treechildren:not(.autocomplete-treebody)::-moz-tree-row(hover) {
-        background-image: linear-gradient(@hoverGradientColor2@, @hoverGradientColor2@);
-      }
-
-      treechildren:not(.autocomplete-treebody)::-moz-tree-row(hover, current) {
-        background-image: linear-gradient(@hoverGradientColor2@, @hoverGradientColor2@);
-      }
-
-      treechildren:not(.autocomplete-treebody)::-moz-tree-row(hover, selected) {
-        background-image: linear-gradient(@hoverAndCurrentFocusGradientColor2@, @hoverAndCurrentFocusGradientColor2@);
-      }
+  @media (-moz-os-version: windows-win8) {
+    treechildren {
+      --treechildren-outline: 1px solid var(--treechildren-2ndBorderColor);
+      --treechildren-selectedBorder: var(--treechildren-selectedColor);
+      --treechildren-selectedBottomBorder: var(--treechildren-selectedColor);
+      --treechildren-selectedImage: linear-gradient(rgba(190,190,190,.4), rgba(190,190,190,.4));
+      --treechildren-currentFocusBorder: var(--treechildren-currentColor);
+      --treechildren-currentFocusBottomBorder: var(--treechildren-currentColor);
+      --treechildren-selectedFocusBorder: rgb(132,172,221) var(--treechildren-2ndBorderColor);
+      --treechildren-selectedFocusBottomBorder: var(--treechildren-currentColor);
+      --treechildren-selectedFocusImage: linear-gradient(rgba(131,183,249,.375), rgba(131,183,249,.375));
+      --treechildren-selectedFocusBackground: transparent;
+      --treechildren-selectedFocusCurrentBorder: var(--treechildren-currentColor);
+      --treechildren-selectedFocusCurrentBottomBorder: var(--treechildren-currentColor);
+      --treechildren-selectedFocusCurrentImage: linear-gradient(rgba(131,183,249,.5), rgba(131,183,249,.5));
+      --treechildren-hoverBorder: rgb(184,214,251);
+      --treechildren-hoverBottomBorder: rgb(184,214,251);
+      --treechildren-hoverImage: linear-gradient(rgba(131,183,249,.16), rgba(131,183,249,.16));
+      --treechildren-hoverSelectedBorder: var(--treechildren-currentColor);
+      --treechildren-hoverSelectedBottomBorder: var(--treechildren-currentColor);
+      --treechildren-hoverSelectedImage: linear-gradient(rgba(131,183,249,.5), rgba(131,183,249,.5));
     }
   }
 }

--- a/toolkit/themes/windows/global/tree/twisty-10.svg
+++ b/toolkit/themes/windows/global/tree/twisty-10.svg
@@ -1,0 +1,35 @@
+<?xml version="1.0"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="9" height="9">
+  <style>
+    use:not(:target) {
+      display: none;
+    }
+    use {
+      stroke: #b6b6b6;
+      stroke-width: 1.6;
+      fill: none;
+    }
+    use[id^="open"] {
+      stroke: #636363;
+    }
+    use[id*="-hover"] {
+      stroke: #4ed0f9;
+    }
+  </style>
+  <defs>
+    <path id="clsd-shape" d="m 2.5,0.5 4,4 -4,4"/>
+    <path id="open-shape" d="m 8.5,2.5 -4,4 -4,-4"/>
+    <path id="clsd-rtl-shape" d="m 6.5,0.5 -4,4 4,4"/>
+  </defs>
+  <use id="clsd" xlink:href="#clsd-shape"/>
+  <use id="clsd-hover" xlink:href="#clsd-shape"/>
+  <use id="open" xlink:href="#open-shape"/>
+  <use id="open-hover" xlink:href="#open-shape"/>
+  <use id="clsd-rtl" xlink:href="#clsd-rtl-shape"/>
+  <use id="clsd-hover-rtl" xlink:href="#clsd-rtl-shape"/>
+  <use id="open-rtl" xlink:href="#open-shape"/>
+  <use id="open-hover-rtl" xlink:href="#open-shape"/>
+</svg>

--- a/toolkit/themes/windows/global/tree/twisty.svg
+++ b/toolkit/themes/windows/global/tree/twisty.svg
@@ -1,0 +1,39 @@
+<?xml version="1.0"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="9" height="9">
+  <style>
+    use:not(:target) {
+      display: none;
+    }
+    use {
+      stroke: #74747b;
+      stroke-opacity: 0.85;
+      fill: none;
+    }
+    use[id^="open"] {
+      stroke: #636363;
+      stroke-opacity: 1;
+    }
+    use[id*="-hover"] {
+      stroke: #1cc4f7;
+      stroke-opacity: 1;
+      fill: #c0e8f9;
+    }
+  </style>
+  <defs>
+    <path id="clsd-shape" d="m 2.5,0.5 4,4 -4,4 z"/>
+    <path id="open-shape" d="M 7.5,3 7.5,7.5 3,7.5 3,6.5 6.5,3 Z"/>
+    <path id="clsd-rtl-shape" d="m 6.5,0.5 -4,4 4,4 z"/>
+    <path id="open-rtl-shape" d="m 1.5,3 0,4.5 4.5,0 0,-1 L 2.5,3 Z"/>
+  </defs>
+  <use id="clsd" xlink:href="#clsd-shape"/>
+  <use id="clsd-hover" xlink:href="#clsd-shape"/>
+  <use id="open" xlink:href="#open-shape"/>
+  <use id="open-hover" xlink:href="#open-shape"/>
+  <use id="clsd-rtl" xlink:href="#clsd-rtl-shape"/>
+  <use id="clsd-hover-rtl" xlink:href="#clsd-rtl-shape"/>
+  <use id="open-rtl" xlink:href="#open-rtl-shape"/>
+  <use id="open-hover-rtl" xlink:href="#open-rtl-shape"/>
+</svg>

--- a/toolkit/themes/windows/mozapps/extensions/extensions.css
+++ b/toolkit/themes/windows/mozapps/extensions/extensions.css
@@ -180,8 +180,7 @@
 }
 
 %ifdef XP_WIN
-@media (-moz-os-version: windows-xp),
-       (-moz-os-version: windows-vista),
+@media (-moz-os-version: windows-vista),
        (-moz-os-version: windows-win7) {
 %endif
   .category:-moz-locale-dir(ltr) {
@@ -313,8 +312,7 @@
   }
 
 %ifdef XP_WIN
-@media (-moz-os-version: windows-xp),
-       (-moz-os-version: windows-vista),
+@media (-moz-os-version: windows-vista),
        (-moz-os-version: windows-win7) {
 %endif
   #header-search {
@@ -1179,8 +1177,7 @@ button.button-link:not([disabled="true"]):active:hover {
 }
 
 %ifdef XP_WIN
-@media (-moz-os-version: windows-xp),
-       (-moz-os-version: windows-vista),
+@media (-moz-os-version: windows-vista),
        (-moz-os-version: windows-win7) {
 %endif
   .header-button {

--- a/toolkit/themes/windows/mozapps/extensions/selectAddons.css
+++ b/toolkit/themes/windows/mozapps/extensions/selectAddons.css
@@ -171,17 +171,15 @@
 }
 
 %ifdef XP_WIN
-@media not all and (-moz-os-version: windows-xp) {
-  .progress-label,
-  #footer-label {
-    font-style: italic;
-  }
+.progress-label,
+#footer-label {
+  font-style: italic;
+}
 
-  @media (-moz-windows-default-theme) {
-    #footer {
-      background-color: #f1f5fb;
-      box-shadow: 0px 1px 2px rgb(204,214,234) inset;
-    }
+@media (-moz-windows-default-theme) {
+  #footer {
+    background-color: #f1f5fb;
+    box-shadow: 0px 1px 2px rgb(204,214,234) inset;
   }
 }
 %endif


### PR DESCRIPTION
This updates the `listbox` and `tree` stylings for Windows 10. In doing so, it also replaces the PNGs used for `twisty` on Windows with SVGs instead, with a separate SVG for Windows 10 due to its different style. This also replaces defines within `listbox.css` and `tree.css` with CSS variables, in order to help reduce the amount of redundancy. The old `twisty` PNGs have been left for backwards-compatibility purposes (who knows if an addon uses these perhaps), plus they exist as fallback on the Linux theme (currently they are `-moz-appearance`'d there anyway). If you didn't want them to exist at all in the Windows theme though they could be easily moved to the Linux theme.

I also did some purging of `windows-xp` media queries which inadvertently slipped in when I was working on #107, as these came from upstream. These are probably fine to leave in, but redundant since we won't be supporting XP anyway.