### PR TITLE
Fix incorrect scope object for nodeIsFolder method call

### DIFF
--- a/browser/components/places/content/browserPlacesViews.js
+++ b/browser/components/places/content/browserPlacesViews.js
@@ -1313,7 +1313,7 @@ PlacesToolbar.prototype = {
         elt.localName != "menupopup") {
       let eltRect = elt.getBoundingClientRect();
       let eltIndex = Array.indexOf(this._rootElt.childNodes, elt);
-      if (PlacesUIUtils.nodeIsFolder(elt._placesNode) &&
+      if (PlacesUtils.nodeIsFolder(elt._placesNode) &&
           !PlacesUIUtils.isContentsReadOnly(elt._placesNode)) {
         // This is a folder.
         // If we are in the middle of it, drop inside it.


### PR DESCRIPTION
This resolves #63 and makes it possible to drag tabs between already existing bookmarks in the toolbar (the tabs had been moved into separate windows before).