### PR TITLE
Bookmarks dragged & dropped from special folders onto the bookmarks toolbar display 'null' as a title

### DIFF
--- a/browser/components/places/content/browserPlacesViews.js
+++ b/browser/components/places/content/browserPlacesViews.js
@@ -955,7 +955,7 @@ PlacesToolbar.prototype = {
     else {
       button = document.createElement("toolbarbutton");
       button.className = "bookmark-item";
-      button.setAttribute("label", aChild.title);
+      button.setAttribute("label", aChild.title || "");
       let icon = aChild.icon;
       if (icon)
         button.setAttribute("image", icon);


### PR DESCRIPTION
See: [1112618](https://bugzilla.mozilla.org/show_bug.cgi?id=1112618)

The same problem is also in Pale Moon (including the latest version 26).
(https://github.com/MoonchildProductions/Pale-Moon/blob/26.4.0_Release/browser/components/places/content/browserPlacesViews.js#L958)

Thank you in advance.
