### PR TITLE
The gcli commands - addon - plugins

### DIFF
--- a/browser/locales/en-US/chrome/browser/devtools/gclicommands.properties
+++ b/browser/locales/en-US/chrome/browser/devtools/gclicommands.properties
@@ -794,6 +794,30 @@ addonAlreadyDisabled=%S is already disabled.
 # command when an add-on is disabled.
 addonDisabled=%S disabled.
 
+# LOCALIZATION NOTE (addonCtpDesc) A very short description of the
+# 'addon ctp <type>' command. This string is designed to be shown in a menu
+# alongside the command name, which is why it should be as short as possible.
+addonCtpDesc=Set the specified plugin to click-to-play.
+
+# LOCALIZATION NOTE (addonCtp) Used in the output of the 'addon ctp'
+# command when a plugin is set to click-to-play.
+addonCtp=%S set to click-to-play.
+
+# LOCALIZATION NOTE (addonAlreadyCtp) Used in the output of the
+# 'addon ctp' command when an attempt is made to set a plugin to
+# click-to-play that is already set to click-to-play.
+addonAlreadyCtp=%S is already set to click-to-play.
+
+# LOCALIZATION NOTE (addonCantCtp) Used in the output of the 'addon
+# ctp' command when an attempt is made to set an addon to click-to-play,
+# but the addon is not a plugin.
+addonCantCtp=%S cannot be set to click-to-play because it is not a plugin.
+
+# LOCALIZATION NOTE (addonNoCtp) Used in the output of the 'addon
+# ctp' command when an attempt is made to set an addon to click-to-play,
+# but the plugin cannot be set to click-to-play for some reason.
+addonNoCtp=%S cannot be set to click-to-play.
+
 # LOCALIZATION NOTE (exportDesc) A very short description of the 'export'
 # command. This string is designed to be shown in a menu alongside the command
 # name, which is why it should be as short as possible.

--- a/toolkit/devtools/gcli/commands/addon.js
+++ b/toolkit/devtools/gcli/commands/addon.js
@@ -274,7 +274,7 @@ exports.items = [
         args.addon.userDisabled = AddonManager.STATE_ASK_TO_ACTIVATE;
 
         if (args.addon.userDisabled !== AddonManager.STATE_ASK_TO_ACTIVATE) {
-          // Some plugins (e.g. OpenH264 shipped with Firefox) cannot be set to
+          // Some plugins (e.g. OpenH264 shipped with Pale Moon) cannot be set to
           // click-to-play. Handle this.
 
           return gcli.lookupFormat("addonNoCtp", [ name ]);

--- a/toolkit/devtools/gcli/commands/addon.js
+++ b/toolkit/devtools/gcli/commands/addon.js
@@ -252,5 +252,38 @@ exports.items = [
 
       return gcli.lookupFormat("addonAlreadyDisabled", [ name ]);
     }
+  },
+  {
+    name: "addon ctp",
+    description: gcli.lookup("addonCtpDesc"),
+    params: [
+      {
+        name: "addon",
+        type: "addon",
+        description: gcli.lookup("addonNameDesc")
+      }
+    ],
+    exec: function(args, context) {
+      let name = (args.addon.name + " " + args.addon.version).trim();
+      if (args.addon.type !== "plugin") {
+        return gcli.lookupFormat("addonCantCtp", [ name ]);
+      }
+
+      if (!args.addon.userDisabled ||
+          args.addon.userDisabled === true) {
+        args.addon.userDisabled = AddonManager.STATE_ASK_TO_ACTIVATE;
+
+        if (args.addon.userDisabled !== AddonManager.STATE_ASK_TO_ACTIVATE) {
+          // Some plugins (e.g. OpenH264 shipped with Firefox) cannot be set to
+          // click-to-play. Handle this.
+
+          return gcli.lookupFormat("addonNoCtp", [ name ]);
+        }
+
+        return gcli.lookupFormat("addonCtp", [ name ]);
+      }
+
+      return gcli.lookupFormat("addonAlreadyCtp", [ name ]);
+    }
   }
 ];


### PR DESCRIPTION
See: [1106353](https://bugzilla.mozilla.org/show_bug.cgi?id=1106353)

The same problem is also in Pale Moon (including the latest version 26), but... In which case it would have to adjust...
(https://github.com/MoonchildProductions/Pale-Moon/blob/26.4.0_Release/browser/devtools/commandline/BuiltinCommands.jsm)

Thank you in advance.
